### PR TITLE
fix building of Youtube search parameters

### DIFF
--- a/lib/WWW/PipeViewer/Proto.pm
+++ b/lib/WWW/PipeViewer/Proto.pm
@@ -1,0 +1,44 @@
+package WWW::PipeViewer::Proto;
+
+use warnings;
+
+require Exporter;
+@ISA = qw(Exporter);
+
+# https://developers.google.com/protocol-buffers/docs/encoding#varints
+sub _encode_varint {
+    my ($uint) = @_;
+    my @bytes;
+    do {
+        my $b = $uint & 127;
+        $uint >>= 7;
+        if ($uint) {
+            $b += 128
+        }
+        push @bytes, $b;
+    } while ($uint);
+    return @bytes;
+}
+
+sub _proto_field {
+   my ($wire_type, $field_number, @data_bytes) = @_;
+   unshift @data_bytes, _encode_varint(($field_number << 3) | $wire_type);
+   return @data_bytes;
+}
+
+sub proto_uint {
+    my ($field_number, $uint) = @_;
+    return _proto_field(0, $field_number, _encode_varint($uint));
+}
+
+sub proto_nested {
+    my ($field_number, @data_bytes) = @_;
+    return _proto_field(2, $field_number, _encode_varint(scalar @data_bytes), @data_bytes);
+}
+
+our @EXPORT = qw(
+    proto_uint
+    proto_nested
+);
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Correctly support different combinations of ordering and filters (e.g. like sorting by upload date and for only short HD videos), as well as paging.

Partially fix #57.

Example:
```bash
# With 0.2.3:

▸ ./pipe-viewer --order=upload_date --hd 'drum playthrough' 

 1. NOCTURNAL BLOODLUST - Dagger (Drum Playthrough by Natsu)                  NOCTURNAL BLOODLUST  1d  1.7K    04:18
 2. DISTANT - ''Aeons Of Oblivion'' Drum Playthrough                          DISTANT              1m  2.3K    04:02
 3. Whitechapel - A Bloodsoaked Symphony (Drum Playthrough)                   Metal Blade Records 10m  198K    04:30
 4. LORNA SHORE - Austin Archey - King Ov Deception (OFFICIAL DRUM PLAYTHROUG Century Media Recor  1y  282K    04:01
 5. Polyphia - Playing God (Drum Playthrough)                                 Polyphia             2m  595K    03:26
[…]

# The search order is not respected! With this PR:

▸ ./pipe-viewer --order=upload_date --hd 'drum playthrough'

 1. คืนที่ปวดร้าว The Yers - Original Drum Playthrough                            CT Music Shop / Cho  0d    84    03:29
 2. Nick Menza - LUCRETIA Drum Playthrough                                    Menza Nation         0d   162    04:21
 3. 馬面人Horseman(兩棲人)~漂亮寶貝~Drum Playthrough                          HorseMan馬面人       0d     4    03:43
 4. Bohemian Betyars - Lebegő (Daniel Danko // Drum Playthrough)              Bohemian Betyars //  0d   116    03:22
 5. Dear Seattle: Here To Stay Drum Playthrough                               Josh Mckay           0d    17    04:08
[…]
```


Note: because asking for less than 20 maximum results breaks paging (e.g. after searching for the first 5 results of page 1, the next page link will return result 20-25, instead 5-10), the supported range is limited to 20-50.