### PR TITLE
improve Youtube search and the GUI

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -52,6 +52,8 @@ use File::Spec::Functions qw(
 
 use Scalar::Util qw(looks_like_number);
 
+use List::Util qw(max min uniq);
+
 require Storable;
 binmode(STDOUT, ':utf8');
 
@@ -727,19 +729,9 @@ foreach my $path ($CONFIG{cache_dir}) {
             undef $history{CORE::fc($line)};
         }
 
-        require List::Util;
-
-        # Workaround for List::Util < 1.45
-        if (!defined(&List::Util::uniq)) {
-            *List::Util::uniq = sub {
-                my %seen;
-                grep { !$seen{$_}++ } @_;
-            };
-        }
-
         # Keep only the most recent non-duplicated entries
-        @history        = reverse(List::Util::uniq(reverse(@history)));
-        @search_history = List::Util::uniq(@search_history);
+        @history        = reverse(uniq(reverse(@history)));
+        @search_history = uniq(@search_history);
 
         # Set entry completion
         $completion = Gtk3::EntryCompletion->new;
@@ -4051,11 +4043,9 @@ sub save_session {
 
     my @results = @{$ResultsHistory{results}};
 
-    require List::Util;
-
     my $max   = $CONFIG{remember_session_depth};
-    my @left  = @results[List::Util::max(0, $curr - $max) .. $curr - 1];
-    my @right = @results[$curr + 1 .. List::Util::min($#results, $curr + $max)];
+    my @left  = @results[max(0, $curr - $max) .. $curr - 1];
+    my @right = @results[$curr + 1 .. min($#results, $curr + $max)];
 
     if ($yv_obj->get_debug) {
         say "Session total: ", scalar(@results);

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -52,7 +52,7 @@ use File::Spec::Functions qw(
 
 use Scalar::Util qw(looks_like_number);
 
-use List::Util qw(max min uniq);
+use List::Util qw(any max min pairs uniq);
 
 require Storable;
 binmode(STDOUT, ':utf8');
@@ -225,11 +225,8 @@ my %CONFIG = (
     maxResults       => 10,
     hfr              => 1,        # true to prefer high frame rate (HFR) videos
     resolution       => 'best',
-    videoCaption     => undef,
-    videoDefinition  => undef,
-    videoDimension   => undef,
     videoDuration    => undef,
-    videoLicense     => undef,
+    features         => undef,
     search_for       => 'video',
     order            => 'relevance',
     date             => 'anytime',
@@ -410,9 +407,6 @@ my %objects = (
     'notebook1'              => \my $notebook,
     'comboboxtext9'          => \my $resolution_combobox,
     'comboboxtext8'          => \my $duration_combobox,
-    'comboboxtext3'          => \my $caption_combobox,
-    'comboboxtext4'          => \my $definition_combobox,
-    'comboboxtext5'          => \my $license_combobox,
     'comboboxtext1'          => \my $published_within_combobox,
     'comboboxtext13'         => \my $subscriptions_order_combobox,
     'panel_user_entry'       => \my $panel_user_entry,
@@ -432,6 +426,7 @@ my %objects = (
     'channel_name_save'      => \my $save_channel_name_entry,
     'channel_id_save'        => \my $save_channel_id_entry,
     'main-menu-history-menu' => \my $history_menu,
+    'features_flowbox'       => \my $features_flowbox,
               );
 
 while (my ($key, $value) = each %objects) {
@@ -526,6 +521,34 @@ if (!exists $CONFIG->{resolution} && exists $CONFIG->{active_resolution_combobox
     $CONFIG->{resolution} = $CONFIG->{active_resolution_combobox};
 }
 delete $CONFIG->{active_resolution_combobox};
+
+# Features handling.
+my @FEATURES;
+
+sub toggle_features {
+    my $enabled = shift @_;
+    if ($enabled) {
+        @FEATURES = sort(uniq(@FEATURES, @_));
+    } else {
+        @FEATURES = grep { my $feat = $_; ! grep $feat eq $_, @_ } @FEATURES;
+    }
+    $CONFIG->{features} = \@FEATURES;
+}
+
+toggle_features 1, @{$CONFIG->{features}};
+my @feature_options = qw(
+    videoCaption     1                 subtitles
+    videoCaption     true              subtitles
+    videoDefinition  high              hd
+    videoDimension   3d                3d
+    videoLicense     creative_commons  creative_commons
+);
+while (scalar @feature_options) {
+    (my $option_name, my $option_value, my $feature, @feature_options) = @feature_options;
+    if (($CONFIG->{$option_name} // '') eq $option_value) {
+        toggle_features 1, $feature;
+    }
+}
 
 # Get valid config keys
 my @valid_keys = grep { exists $CONFIG{$_} } keys %{$CONFIG};
@@ -995,9 +1018,28 @@ sub apply_configuration {
     apply_combobox_configuration($duration_combobox, "videoDuration");
     apply_combobox_configuration($order_combobox, "order");
     apply_combobox_configuration($published_within_combobox, "date");
-    apply_combobox_configuration($definition_combobox, "videoDefinition");
-    apply_combobox_configuration($caption_combobox, "videoCaption");
-    apply_combobox_configuration($license_combobox, "videoLicense");
+
+    foreach my $pair (pairs (
+            'live'            , 'Live',
+            '4k'              , '4K',
+            'hd'              , 'HD',
+            'subtitles'       , 'Subtitles/CC',
+            'creative_commons', 'Creative Commons',
+            '360'             , '360°',
+            'vr180'           , 'VR180',
+            '3d'              , '3D',
+            'hdr'             , 'HDR',
+        )) {
+            my ($feat, $label) = @$pair;
+            my $button = Gtk3::CheckButton->new_with_label($label);
+            $features_flowbox->add($button);
+            $button->set_visible(1);
+            $button->signal_connect('toggled', sub {
+                toggle_features $button->get_active, $feat;
+                $yv_obj->set_features(\@FEATURES);
+            });
+        $button->set_active(any {$feat eq $_} @FEATURES);
+    }
 
     # Resize the main window
     $mainw->set_default_size(split(/x/i, $CONFIG{mainw_size}, 2));
@@ -1891,18 +1933,6 @@ sub combobox_panel_account_changed {
 
 sub combobox_channel_type_changed {
     $CONFIG{active_channel_type_combobox} = $channel_type_combobox->get_active;
-}
-
-sub combobox_definition_changed {
-    combobox_changed($definition_combobox, "videoDefinition", 1);
-}
-
-sub combobox_license_changed {
-    combobox_changed($license_combobox, "videoLicense", 1);
-}
-
-sub combobox_caption_changed {
-    combobox_changed($caption_combobox, "videoCaption", 1);
 }
 
 sub combobox_published_within_changed {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -50,6 +50,8 @@ use File::Spec::Functions qw(
   file_name_is_absolute
 );
 
+use Scalar::Util qw(looks_like_number);
+
 require Storable;
 binmode(STDOUT, ':utf8');
 
@@ -174,7 +176,6 @@ my %symbols = (
 my %CONFIG = (
 
     # Combobox values
-    active_resolution_combobox          => 0,
     active_more_options_expander        => 0,
     active_panel_account_combobox       => 0,
     active_channel_type_combobox        => 0,
@@ -222,8 +223,14 @@ my %CONFIG = (
     maxResults       => 10,
     hfr              => 1,        # true to prefer high frame rate (HFR) videos
     resolution       => 'best',
+    videoCaption     => undef,
+    videoDefinition  => undef,
     videoDimension   => undef,
+    videoDuration    => undef,
     videoLicense     => undef,
+    search_for       => 'video',
+    order            => 'relevance',
+    date             => 'anytime',
     region           => undef,
 
     comments_width => 80,         # wrap comments longer than `n` characters
@@ -511,6 +518,12 @@ if (exists $CONFIG->{watched_file}) {
 if (exists $CONFIG->{youtube_users_file}) {
     $CONFIG->{saved_channels_file} = delete $CONFIG->{youtube_users_file};
 }
+
+# Backward compatibility with old config format.
+if (!exists $CONFIG->{resolution} && exists $CONFIG->{active_resolution_combobox}) {
+    $CONFIG->{resolution} = $CONFIG->{active_resolution_combobox};
+}
+delete $CONFIG->{active_resolution_combobox};
 
 # Get valid config keys
 my @valid_keys = grep { exists $CONFIG{$_} } keys %{$CONFIG};
@@ -915,14 +928,34 @@ require WWW::PipeViewer::Utils;
 my $yv_utils = WWW::PipeViewer::Utils->new(thousand_separator => $CONFIG{thousand_separator},
                                            youtube_url_format => $CONFIG{youtube_video_url},);
 
-# Set default combobox values
-$definition_combobox->set_active(0);
-$duration_combobox->set_active(0);
-$caption_combobox->set_active(0);
-$order_combobox->set_active(0);
-
 # Spin button start with page
 $spin_start_with_page->set_value(1);
+
+sub apply_combobox_configuration {
+    my ($combo, $option) = @_;
+    my $value = $CONFIG{$option};
+
+    if (!$combo->set_active_id($value) && looks_like_number($value)) {
+        # For backward compatibility with old config format.
+        $combo->set_active($value);
+    }
+
+    if ($combo->get_active == -1) {
+        # Default to first item.
+        $combo->set_active(0);
+    }
+}
+
+sub apply_yt_option {
+    my ($option_name, $value) = @_;
+
+    my $setter = "set_$option_name";
+    my $set_value = $yv_obj->$setter($value);
+
+    if (defined $value && $value ne ($set_value // '')) {
+        warn "[!] Invalid value <", $value // 'undef', "> for option <$option_name>.\n";
+    }
+}
 
 sub apply_configuration {
 
@@ -940,11 +973,9 @@ sub apply_configuration {
     $channel_type_combobox->set_active($CONFIG{active_channel_type_combobox});
     $subscriptions_order_combobox->set_active($CONFIG{active_subscriptions_order_combobox});
 
-    $published_within_combobox->set_active(0);
-
     foreach my $option_name (
                              qw(
-                             maxResults videoDimension videoLicense
+                             maxResults
                              region debug http_proxy user_agent
                              timeout cookie_file ytdl ytdl_cmd
                              api_host prefer_mp4 prefer_av1
@@ -954,17 +985,8 @@ sub apply_configuration {
                              bypass_age_gate_with_proxy
                              )
       ) {
-
-        if (defined $CONFIG{$option_name}) {
-            my $code      = \&{"WWW::PipeViewer::set_$option_name"};
-            my $value     = $CONFIG{$option_name};
-            my $set_value = $yv_obj->$code($value);
-
-            if (not defined($set_value) or $set_value ne $value) {
-                warn "[!] Invalid value <$value> for option <$option_name>.\n";
-            }
-        }
-    }
+          apply_yt_option($option_name);
+      }
 
     # Maximum number of results per page
     $spin_results->set_value($CONFIG{maxResults});
@@ -975,25 +997,15 @@ sub apply_configuration {
     # Set the "More options" expander
     $more_options_expander->set_expanded($CONFIG{active_more_options_expander});
 
-    my %resolution = (
-                      'best' => 0,
-                      '2160' => 1,
-                      '1440' => 2,
-                      '1080' => 3,
-                      '720'  => 4,
-                      '480'  => 5,
-                      '360'  => 6,
-                      '240'  => 7,
-                     );
-
-    my $name = ($CONFIG{resolution} =~ /^(\d+)/) ? $1 : $CONFIG{resolution};
-
-    if (exists $resolution{$name}) {
-        $resolution_combobox->set_active($resolution{$name});
-    }
-    else {
-        $resolution_combobox->set_active($CONFIG{active_resolution_combobox});
-    }
+    # Set default combobox values
+    apply_combobox_configuration($search_for_combobox, "search_for");
+    apply_combobox_configuration($resolution_combobox, "resolution");
+    apply_combobox_configuration($duration_combobox, "videoDuration");
+    apply_combobox_configuration($order_combobox, "order");
+    apply_combobox_configuration($published_within_combobox, "date");
+    apply_combobox_configuration($definition_combobox, "videoDefinition");
+    apply_combobox_configuration($caption_combobox, "videoCaption");
+    apply_combobox_configuration($license_combobox, "videoLicense");
 
     # Resize the main window
     $mainw->set_default_size(split(/x/i, $CONFIG{mainw_size}, 2));
@@ -1843,24 +1855,30 @@ sub delete_selected_row {
 }
 
 # Combo boxes changes
+
+sub combobox_changed {
+    my ($combo, $option, $update_yt_option) = @_;
+    my $value = $combo->get_active_id;
+    $CONFIG{$option} = $value;
+    if ($update_yt_option) {
+        apply_yt_option($option, $value);
+    }
+}
+
+sub combobox_search_for_changed {
+    combobox_changed($search_for_combobox, "search_for");
+}
+
 sub combobox_order_changed {
-    $yv_obj->set_order($order_combobox->get_active_text);
+    combobox_changed($order_combobox, "order", 1);
 }
 
 sub combobox_resolution_changed {
-    $CONFIG{active_resolution_combobox} = $resolution_combobox->get_active;
-    my $res = $resolution_combobox->get_active_text;
-    $CONFIG{resolution} = $res =~ /^(\d+)p\z/ ? $1 : $res;
+    combobox_changed($resolution_combobox, "resolution");
 }
 
 sub combobox_duration_changed {
-    my $text = $duration_combobox->get_active_text;
-    $yv_obj->set_videoDuration($text);
-}
-
-sub combobox_caption_changed {
-    my $text = $caption_combobox->get_active_text;
-    $yv_obj->set_videoCaption($text);
+    combobox_changed($duration_combobox, "videoDuration", 1);
 }
 
 sub combobox_subscriptions_order_changed {
@@ -1884,25 +1902,19 @@ sub combobox_channel_type_changed {
 }
 
 sub combobox_definition_changed {
-    my $text = $definition_combobox->get_active_text;
-    $yv_obj->set_videoDefinition($text);
+    combobox_changed($definition_combobox, "videoDefinition", 1);
 }
 
 sub combobox_license_changed {
-    my $text = $license_combobox->get_active_text;
-    $yv_obj->set_videoLicense($text);
+    combobox_changed($license_combobox, "videoLicense", 1);
+}
+
+sub combobox_caption_changed {
+    combobox_changed($caption_combobox, "videoCaption", 1);
 }
 
 sub combobox_published_within_changed {
-
-    my $period = $published_within_combobox->get_active_text;
-
-    if ($period =~ /^any/) {
-        $yv_obj->set_date(undef);
-    }
-    else {
-        $yv_obj->set_date($period);
-    }
+    combobox_changed($published_within_combobox, "date", 1)
 }
 
 # Spin buttons changes
@@ -2471,8 +2483,7 @@ sub search {
         $yv_obj->set_channelId();
     }
 
-    my $type = $search_for_combobox->get_active_text;
-    display_results($yv_obj->search_for($type, $keywords));
+    display_results($yv_obj->search_for($CONFIG{search_for}, $keywords));
 
     return 1;
 }

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -53,6 +53,8 @@ use if ($DEVEL = -w __FILE__), lib => (abs_path(__FILE__.'/../../lib'),);
 use WWW::PipeViewer v0.2.3;
 use WWW::PipeViewer::RegularExpressions;
 
+use List::Util qw(uniq);
+
 require Storable;
 
 use File::Spec::Functions qw(
@@ -196,12 +198,9 @@ my %CONFIG = (
     maxResults      => 20,
     hfr             => 1,        # true to prefer high frame rate (HFR) videos
     resolution      => 'best',
-    videoDefinition => undef,
-    videoDimension  => undef,
-    videoLicense    => undef,
-    videoCaption    => undef,
     videoDuration   => undef,
 
+    features => undef,
     order  => undef,
     date   => undef,
     region => undef,
@@ -464,6 +463,16 @@ EOD
 }
 
 our $CONFIG;
+our @FEATURES;
+
+sub toggle_features {
+    my $enabled = shift @_;
+    if ($enabled) {
+        @FEATURES = sort(uniq(@FEATURES, @_));
+    } else {
+        @FEATURES = grep { my $feat = $_; ! grep $feat eq $_, @_ } @FEATURES;
+    }
+}
 
 sub load_config {
     my ($config_file) = @_;
@@ -491,6 +500,23 @@ sub load_config {
         $CONFIG->{saved_channels_file} = delete $CONFIG->{youtube_users_file};
         $update_config = 1;
     }
+
+    toggle_features 1, @{$CONFIG->{features}};
+    my @feature_options = qw(
+        videoCaption     1                 subtitles
+        videoCaption     true              subtitles
+        videoDefinition  high              hd
+        videoDimension   3d                3d
+        videoLicense     creative_commons  creative_commons
+    );
+    while (scalar @feature_options) {
+        (my $option_name, my $option_value, my $feature, @feature_options) = @feature_options;
+        if (($CONFIG->{$option_name} // '') eq $option_value) {
+            toggle_features 1, $feature;
+            $update_config = 1;
+        }
+    }
+    $CONFIG->{features} = \@FEATURES;
 
     # Get valid config keys
     my @valid_keys = grep { exists $CONFIG{$_} } keys %{$CONFIG};
@@ -758,8 +784,14 @@ usage: $execname [options] ([url] | [keywords])
                           valid values: relevance rating upload_date view_count
    --time=s             : short videos published in a time period
                           valid values: hour today week month year
-   --hd!                : search only for videos available in at least 720p
-   --vd=s               : set the video definition (any or high)
+   --360!               : search only for 360° videos
+   --hdr!               : search only for HDR videos
+   --live!              : search only for live videos
+   --vr180!             : search only for VR180 videos
+   --video-definition=s --vd=s:
+                          set the video definition (any, hd, or 4k)
+   --4k                 : shortcut for --video-definition=hd
+   --hd                 : shortcut for --video-definition=4k
    --dimension=s        : set video dimension (any or 3d)
    --license=s          : set video license (any or creative_commons)
    --page=i             : get results starting with a specific page number
@@ -1159,9 +1191,7 @@ sub apply_configuration {
     # ... YOUTUBE OPTIONS ... #
     foreach my $option_name (
                              qw(
-                             videoCaption videoDefinition
-                             videoDimension videoDuration
-                             videoLicense maxResults
+                             videoDuration maxResults
                              api_host date order
                              channelId region debug
                              http_proxy page comments_order
@@ -1185,8 +1215,30 @@ sub apply_configuration {
         }
     }
 
-    if (defined $opt->{hd}) {
-        $yv_obj->set_videoDefinition(delete($opt->{hd}) ? 'high' : undef);
+    my @feature_options = qw(
+        360              1                 360
+        hdr              1                 hdr
+        live             1                 live
+        vr180            1                 vr180
+        videoCaption     1                 subtitles
+        videoDimension   3d                3d
+        videoLicense     creative_commons  creative_commons
+    );
+    while (scalar @feature_options) {
+        (my $option_name, my $option_value, my $feature, @feature_options) = @feature_options;
+        if (defined $opt->{$option_name}) {
+            toggle_features $opt->{$option_name} eq $option_value, $feature;
+        }
+    }
+
+    if (defined $opt->{videoDefinition}) {
+        my $vd = $opt->{videoDefinition};
+        toggle_features $vd eq 'hd', 'hd';
+        toggle_features $vd eq '4k', '4k';
+    }
+
+    if (scalar @FEATURES) {
+        $yv_obj->set_features(\@FEATURES);
     }
 
     if (defined $opt->{author}) {
@@ -1535,7 +1587,12 @@ sub parse_arguments {
         'dimension=s'              => \$opt{videoDimension},
         'license=s'                => \$opt{videoLicense},
         'vd|video-definition=s'    => \$opt{videoDefinition},
-        'hd|high-definition!'      => \$opt{hd},
+        'hd'                       => sub { $opt{videoDefinition} = 'hd' },
+        '4k'                       => sub { $opt{videoDefinition} = '4k' },
+        '360!'                     => \$opt{360},
+        'hdr!'                     => \$opt{hdr},
+        'live!'                    => \$opt{live},
+        'vr180!'                   => \$opt{vr180},
         'I|interactive!'           => \$opt{interactive},
         'convert-to|convert_to=s'  => \$opt{convert_to},
         'keep-original-video!'     => \$opt{keep_original_video},
@@ -5034,27 +5091,24 @@ The keys for each player are:
     novideo    # the no-video mode option
     srt        # option specifying the *SUB* file
 
-=head2 videoCaption
+=head2 features
 
-When set to C<1> or C<"true">, retrieve only videos that contain closed-captions in search results.
-
-=head2 videoDefinition
-
-When set to C<"high">, retrieve only HD videos in search results.
-
-=head2 videoDimension
-
-When set to C<"3d">, retrieve only 3D videos in search results.
+A list of video features, return only videos with the specified features:
+- live: live stream
+- 4k: 4K resolution
+- hd: HD resolution (>=720p)
+- subtitles: video has subtitles/closed-captions
+- creative_commons: Creative Commons license
+- 360: 360° field of view
+- vr180: stereoscopic widh a 180° field of view
+- 3d: 3D
+- hdr: high dynamic range
 
 =head2 videoDuration
 
 Retrieve only short or long videos in search results.
 
 Valid values: "any", "short" (under 4 minutes), "average" (4-20 minutes), and "long" (over 20 minutes).
-
-=head2 videoLicense
-
-When set to C<"creative_commons">, retrieve only videos under the I<Creative Commons> license in search results.
 
 =head2 watch_history
 

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -1186,7 +1186,7 @@ sub apply_configuration {
     }
 
     if (defined $opt->{hd}) {
-        $yv_obj->set_videoDefinition(delete($opt->{hd}) ? 'high' : 'any');
+        $yv_obj->set_videoDefinition(delete($opt->{hd}) ? 'high' : undef);
     }
 
     if (defined $opt->{author}) {

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -5050,7 +5050,7 @@ When set to C<"3d">, retrieve only 3D videos in search results.
 
 Retrieve only short or long videos in search results.
 
-Valid values: "any", "short", "long".
+Valid values: "any", "short" (under 4 minutes), "average" (4-20 minutes), and "long" (over 20 minutes).
 
 =head2 videoLicense
 

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -4761,7 +4761,7 @@ Include or exclude streams in "Dynamic Adaptive Streaming over HTTP" (DASH) form
 
 Search for videos uploaded within a specific amount of time.
 
-Valid values: "hour", "today", "week", "month", "year".
+Valid values: "anytime", "hour", "today", "week", "month", "year".
 
 =head2 debug
 

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -71,7 +71,7 @@ my %valid_options = (
     # Video only options
     videoCaption    => {valid => [qw(1 true)],           default => undef},
     videoDefinition => {valid => [qw(high standard)],    default => undef},
-    videoDimension  => {valid => [qw(2d 3d)],            default => undef},
+    videoDimension  => {valid => [qw(3d)],               default => undef},
     videoDuration   => {valid => [qw(short long)],       default => undef},
     videoLicense    => {valid => [qw(creative_commons)], default => undef},
     region          => {valid => qr/^[A-Z]{2}\z/i,       default => undef},

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -63,8 +63,8 @@ my %valid_options = (
     page       => {valid => qr/^(?!0+\z)\d+\z/,                            default => 1},
     http_proxy => {valid => qr/./,                                         default => undef},
     maxResults => {valid => [1 .. 50],                                     default => 10},
-    order      => {valid => [qw(relevance rating upload_date view_count)], default => undef},
-    date       => {valid => [qw(hour today week month year)],              default => undef},
+    order      => {valid => [qw(relevance rating upload_date view_count)], default => 'relevance'},
+    date       => {valid => [qw(anytime hour today week month year)],      default => 'anytime'},
 
     channelId => {valid => qr/^[-\w]{2,}\z/, default => undef},
 

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -69,12 +69,12 @@ my %valid_options = (
     channelId => {valid => qr/^[-\w]{2,}\z/, default => undef},
 
     # Video only options
-    videoCaption    => {valid => [qw(1 true)],           default => undef},
-    videoDefinition => {valid => [qw(high)],             default => undef},
-    videoDimension  => {valid => [qw(3d)],               default => undef},
-    videoDuration   => {valid => [qw(short long)],       default => undef},
-    videoLicense    => {valid => [qw(creative_commons)], default => undef},
-    region          => {valid => qr/^[A-Z]{2}\z/i,       default => undef},
+    videoCaption    => {valid => [qw(1 true)],             default => undef},
+    videoDefinition => {valid => [qw(high)],               default => undef},
+    videoDimension  => {valid => [qw(3d)],                 default => undef},
+    videoDuration   => {valid => [qw(short average long)], default => undef},
+    videoLicense    => {valid => [qw(creative_commons)],   default => undef},
+    region          => {valid => qr/^[A-Z]{2}\z/i,         default => undef},
 
     comments_order      => {valid => [qw(top new)],                       default => 'top'},
     subscriptions_order => {valid => [qw(alphabetical relevance unread)], default => undef},

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -70,7 +70,7 @@ my %valid_options = (
 
     # Video only options
     videoCaption    => {valid => [qw(1 true)],           default => undef},
-    videoDefinition => {valid => [qw(high standard)],    default => undef},
+    videoDefinition => {valid => [qw(high)],             default => undef},
     videoDimension  => {valid => [qw(3d)],               default => undef},
     videoDuration   => {valid => [qw(short long)],       default => undef},
     videoLicense    => {valid => [qw(creative_commons)], default => undef},

--- a/lib/WWW/PipeViewer/InitialData.pm
+++ b/lib/WWW/PipeViewer/InitialData.pm
@@ -871,20 +871,8 @@ sub yt_search {
         push @filters, proto_uint(2, $_TYPE{$args{type} // 'video'});
         push @filters, proto_uint(3, $_DURATION{$self->get_videoDuration // 'any'});
 
-        my @feature_options = qw(
-            videoCaption     1                 subtitles
-            videoCaption     true              subtitles
-            videoDefinition  high              hd
-            videoLicense     creative_commons  creative_commons
-            videoDimension   3d                3d
-        );
-
-        while (scalar @feature_options) {
-            (my $option_name, my $option_value, my $feature, @feature_options) = @feature_options;
-            my $method = "get_$option_name";
-            if (($self->$method || 0) eq $option_value) {
-                push @filters, proto_uint($_FEATURES{$feature}, 1);
-            }
+        foreach my $feat (@{$self->get_features || []}) {
+            push @filters, proto_uint($_FEATURES{$feat}, 1);
         }
 
         push @sp, proto_nested(2, @filters);

--- a/lib/WWW/PipeViewer/Search.pm
+++ b/lib/WWW/PipeViewer/Search.pm
@@ -21,31 +21,7 @@ WWW::PipeViewer::Search - Search for stuff on YouTube
 sub _make_search_url {
     my ($self, %opts) = @_;
 
-    my @features;
-
-    if (defined(my $vd = $self->get_videoDefinition)) {
-        if ($vd eq 'high') {
-            push @features, 'hd';
-        }
-    }
-
-    if (defined(my $vc = $self->get_videoCaption)) {
-        if ($vc eq 'true' or $vc eq '1') {
-            push @features, 'subtitles';
-        }
-    }
-
-    if (defined(my $vd = $self->get_videoDimension)) {
-        if ($vd eq '3d') {
-            push @features, '3d';
-        }
-    }
-
-    if (defined(my $license = $self->get_videoLicense)) {
-        if ($license eq 'creative_commons') {
-            push @features, 'creative_commons';
-        }
-    }
+    my @features = @{$self->get_features || []};
 
     return $self->_make_feed_url(
         'search',

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2
+<!-- Generated with glade 3.40.0 
 
 Copyright (C) Copyright © 2010-2022 Trizen
 
@@ -22,7 +22,7 @@ Author: Trizen https://github.com/trizen
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.12"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name GTK Pipe Viewer -->
   <!-- interface-description Search and play YouTube videos. -->
@@ -1089,88 +1089,6 @@ Author: Trizen https://github.com/trizen
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkFrame" id="frame19">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label-xalign">0</property>
-                                                <property name="shadow-type">none</property>
-                                                <child>
-                                                  <object class="GtkAlignment" id="alignment18">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="left-padding">12</property>
-                                                    <child>
-                                                      <object class="GtkComboBoxText" id="comboboxtext3">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos that have captions.</property>
-                                                        <property name="active">0</property>
-                                                        <items>
-                                                          <item translatable="yes">Any</item>
-                                                          <item id="true" translatable="yes">With Subtitles/CC</item>
-                                                        </items>
-                                                        <signal name="changed" handler="combobox_caption_changed" swapped="no"/>
-                                                      </object>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                                <child type="label">
-                                                  <object class="GtkLabel" id="label21">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;b&gt;Video Caption:&lt;/b&gt;</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkFrame" id="frame20">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label-xalign">0</property>
-                                                <property name="shadow-type">none</property>
-                                                <child>
-                                                  <object class="GtkAlignment" id="alignment19">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="left-padding">12</property>
-                                                    <child>
-                                                      <object class="GtkComboBoxText" id="comboboxtext4">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only HD videos (720p+ resolution).</property>
-                                                        <property name="active">0</property>
-                                                        <items>
-                                                          <item translatable="yes">Any</item>
-                                                          <item id="high" translatable="yes">HD</item>
-                                                        </items>
-                                                        <signal name="changed" handler="combobox_definition_changed" swapped="no"/>
-                                                      </object>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                                <child type="label">
-                                                  <object class="GtkLabel" id="label25">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;b&gt;Video Definition:&lt;/b&gt;</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">4</property>
-                                              </packing>
-                                            </child>
-                                            <child>
                                               <object class="GtkFrame" id="frame15">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
@@ -1182,16 +1100,11 @@ Author: Trizen https://github.com/trizen
                                                     <property name="can-focus">False</property>
                                                     <property name="left-padding">12</property>
                                                     <child>
-                                                      <object class="GtkComboBoxText" id="comboboxtext5">
+                                                      <object class="GtkFlowBox" id="features_flowbox">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos with Creative Commons license.</property>
-                                                        <property name="active">0</property>
-                                                        <items>
-                                                          <item translatable="yes">Any</item>
-                                                          <item id="creative_commons" translatable="yes">Creative Commons</item>
-                                                        </items>
-                                                        <signal name="changed" handler="combobox_license_changed" swapped="no"/>
+                                                        <property name="homogeneous">True</property>
+                                                        <property name="selection-mode">none</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -1200,7 +1113,7 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkLabel" id="label23">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;b&gt;Video License:&lt;/b&gt;</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Video features:&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
                                                 </child>
@@ -1208,7 +1121,7 @@ Author: Trizen https://github.com/trizen
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">5</property>
+                                                <property name="position">3</property>
                                               </packing>
                                             </child>
                                             <child>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -959,11 +959,12 @@ Author: Trizen https://github.com/trizen
                                                             <property name="tooltip-text" translatable="yes">Type of search results</property>
                                                             <property name="active">0</property>
                                                             <items>
-                                                            <item translatable="yes">video</item>
-                                                            <item translatable="yes">playlist</item>
-                                                            <item translatable="yes">channel</item>
-                                                            <item translatable="yes">all</item>
+                                                            <item id="video" translatable="yes">Video</item>
+                                                            <item id="playlist" translatable="yes">Playlist</item>
+                                                            <item id="channel" translatable="yes">Channel</item>
+                                                            <item id="all" translatable="yes">All</item>
                                                             </items>
+                                                            <signal name="changed" handler="combobox_search_for_changed" swapped="no"/>
                                                           </object>
                                                           <packing>
                                                             <property name="expand">False</property>
@@ -1013,10 +1014,10 @@ Author: Trizen https://github.com/trizen
                                                             <property name="tooltip-text" translatable="yes">Search order for videos</property>
                                                             <property name="active">0</property>
                                                             <items>
-                                                            <item translatable="yes">relevance</item>
-                                                            <item translatable="yes">rating</item>
-                                                            <item translatable="yes">upload_date</item>
-                                                            <item translatable="yes">view_count</item>
+                                                            <item id="relevance" translatable="yes">Relevance</item>
+                                                            <item id="rating" translatable="yes">Rating</item>
+                                                            <item id="upload_date" translatable="yes">Upload date</item>
+                                                            <item id="view_count" translatable="yes">View count</item>
                                                             </items>
                                                             <signal name="changed" handler="combobox_order_changed" swapped="no"/>
                                                           </object>
@@ -1060,13 +1061,11 @@ Author: Trizen https://github.com/trizen
                                                       <object class="GtkComboBoxText" id="comboboxtext8">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">short – less than 4 minutes long
-long – longer than 20 minutes</property>
                                                         <property name="active">0</property>
                                                         <items>
-                                                          <item translatable="yes">any</item>
-                                                          <item translatable="yes">short</item>
-                                                          <item translatable="yes">long</item>
+                                                          <item translatable="yes">Any</item>
+                                                          <item id="short" translatable="yes">Under 4 minutes</item>
+                                                          <item id="long" translatable="yes">Over 20 minutes</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_duration_changed" swapped="no"/>
                                                       </object>
@@ -1103,11 +1102,11 @@ long – longer than 20 minutes</property>
                                                       <object class="GtkComboBoxText" id="comboboxtext3">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos that have closed-captions</property>
+                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos that have captions.</property>
                                                         <property name="active">0</property>
                                                         <items>
-                                                          <item translatable="yes">any</item>
-                                                          <item translatable="yes">true</item>
+                                                          <item translatable="yes">Any</item>
+                                                          <item id="true" translatable="yes">With Subtitles/CC</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_caption_changed" swapped="no"/>
                                                       </object>
@@ -1144,11 +1143,11 @@ long – longer than 20 minutes</property>
                                                       <object class="GtkComboBoxText" id="comboboxtext4">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos with resolution 720p+</property>
+                                                        <property name="tooltip-text" translatable="yes">Retrieve only HD videos (720p+ resolution).</property>
                                                         <property name="active">0</property>
                                                         <items>
-                                                          <item translatable="yes">any</item>
-                                                          <item translatable="yes">high</item>
+                                                          <item translatable="yes">Any</item>
+                                                          <item id="high" translatable="yes">HD</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_definition_changed" swapped="no"/>
                                                       </object>
@@ -1185,11 +1184,11 @@ long – longer than 20 minutes</property>
                                                       <object class="GtkComboBoxText" id="comboboxtext5">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos with Creative-Commons license</property>
+                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos with Creative Commons license.</property>
                                                         <property name="active">0</property>
                                                         <items>
-                                                          <item translatable="yes">any</item>
-                                                          <item translatable="yes">creative_commons</item>
+                                                          <item translatable="yes">Any</item>
+                                                          <item id="creative_commons" translatable="yes">Creative Commons</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_license_changed" swapped="no"/>
                                                       </object>
@@ -1334,12 +1333,12 @@ long – longer than 20 minutes</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="tooltip-text" translatable="yes">Retrieve only videos newer than this.</property>
                                                             <items>
-                                                            <item translatable="yes">anytime</item>
-                                                            <item translatable="yes">hour</item>
-                                                            <item translatable="yes">today</item>
-                                                            <item translatable="yes">week</item>
-                                                            <item translatable="yes">month</item>
-                                                            <item translatable="yes">year</item>
+                                                            <item id="anytime" translatable="yes">Anytime</item>
+                                                            <item id="hour" translatable="yes">Last hour</item>
+                                                            <item id="today" translatable="yes">Today</item>
+                                                            <item id="week" translatable="yes">This week</item>
+                                                            <item id="month" translatable="yes">This month</item>
+                                                            <item id="year" translatable="yes">This year</item>
                                                             </items>
                                                             <signal name="changed" handler="combobox_published_within_changed" swapped="no"/>
                                                             </object>
@@ -1358,7 +1357,7 @@ long – longer than 20 minutes</property>
                                                           <object class="GtkLabel" id="label35">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;Published within:&lt;/b&gt;</property>
+                                                            <property name="label" translatable="yes">&lt;b&gt;Upload date:&lt;/b&gt;</property>
                                                             <property name="use-markup">True</property>
                                                           </object>
                                                         </child>
@@ -1591,15 +1590,15 @@ Unless the author name is valid, this field is ignored.</property>
 When the specified resolution is not found, the best available resolution is used.</property>
                                                         <property name="active">0</property>
                                                         <items>
-                                                          <item translatable="yes">best</item>
-                                                          <item translatable="yes">2160p</item>
-                                                          <item translatable="yes">1440p</item>
-                                                          <item translatable="yes">1080p</item>
-                                                          <item translatable="yes">720p</item>
-                                                          <item translatable="yes">480p</item>
-                                                          <item translatable="yes">360p</item>
-                                                          <item translatable="yes">240p</item>
-                                                          <item translatable="yes">144p</item>
+                                                          <item id="best" translatable="yes">Best</item>
+                                                          <item id="2160" translatable="yes">2160p</item>
+                                                          <item id="1440" translatable="yes">1440p</item>
+                                                          <item id="1080" translatable="yes">1080p</item>
+                                                          <item id="720" translatable="yes">720p</item>
+                                                          <item id="480" translatable="yes">480p</item>
+                                                          <item id="360" translatable="yes">360p</item>
+                                                          <item id="240" translatable="yes">240p</item>
+                                                          <item id="144" translatable="yes">144p</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_resolution_changed" swapped="no"/>
                                                       </object>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1065,6 +1065,7 @@ Author: Trizen https://github.com/trizen
                                                         <items>
                                                           <item translatable="yes">Any</item>
                                                           <item id="short" translatable="yes">Under 4 minutes</item>
+                                                          <item id="average" translatable="yes">4-20 minutes</item>
                                                           <item id="long" translatable="yes">Over 20 minutes</item>
                                                         </items>
                                                         <signal name="changed" handler="combobox_duration_changed" swapped="no"/>


### PR DESCRIPTION
Improve support for video features filtering: `hd`, `subtitles`, `creative_commons`, `3d`, `live`, `4k`, `360`, `hdr`, and `vr180`. Both the CLI parameters and the GUI have been updated accordingly.

Improve the GUI:
- use IDs rather than indexes when dealing with comboboxes: improve labels and make translations possible
- save back the state of most of those comboboxes (settings panel) to the configuration

Notes:
- the `location` and `purchased` features are not supported, I don't login to Youtube, so there's no way for me to test, but it should be pretty easy to add them.
- this increase the version number of some of the requirements: `List::Util>=1.45` (for `uniq`, released 2016-03-25), `Gtk>=3.12` (for `GtkFlowBox`, released 2014-03-25), `Scalar::Util>=1.39` (for `looks_like_number`, relased 2014-06-05).