### PR TITLE
gui: tweak interface to be less cramped

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -178,7 +178,6 @@ my %symbols = (
 my %CONFIG = (
 
     # Combobox values
-    active_more_options_expander        => 0,
     active_panel_account_combobox       => 0,
     active_channel_type_combobox        => 0,
     active_subscriptions_order_combobox => 0,
@@ -403,7 +402,6 @@ my %objects = (
     'treeviewcolumn2'        => \my $thumbs_column,
     'textview2'              => \my $textview_help,
     'from_author_entry'      => \my $from_author_entry,
-    'more_options_expander'  => \my $more_options_expander,
     'notebook1'              => \my $notebook,
     'comboboxtext9'          => \my $resolution_combobox,
     'comboboxtext8'          => \my $duration_combobox,
@@ -1008,9 +1006,6 @@ sub apply_configuration {
 
     # Enable/disable thumbnails
     $thumbs_checkbutton->set_active($CONFIG{show_thumbs});
-
-    # Set the "More options" expander
-    $more_options_expander->set_expanded($CONFIG{active_more_options_expander});
 
     # Set default combobox values
     apply_combobox_configuration($search_for_combobox, "search_for");
@@ -1973,11 +1968,6 @@ sub toggled_dash_support {
 sub thumbs_checkbutton_toggled {
     $CONFIG{show_thumbs} = ($_[0]->get_active() || 0);
     $thumbs_column->set_visible($CONFIG{show_thumbs});
-}
-
-# "More options" expander
-sub activate_more_options_expander {
-    $CONFIG{active_more_options_expander} = $_[0]->get_expanded() ? 0 : 1;
 }
 
 # Get main window size

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -289,6 +289,7 @@ Author: Trizen https://github.com/trizen
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
         <child>
           <object class="GtkMenuBar" id="menubar1">
             <property name="visible">True</property>
@@ -503,17 +504,7 @@ Author: Trizen https://github.com/trizen
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <child>
-              <object class="GtkImage" id="gif_spinner">
-                <property name="can-focus">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack-type">end</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
+            <property name="border-width">4</property>
             <child>
               <object class="GtkEntry" id="search_entry">
                 <property name="visible">True</property>
@@ -532,6 +523,34 @@ Author: Trizen https://github.com/trizen
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox" id="hbuttonbox6">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="layout-style">spread</property>
+                <child>
+                  <object class="GtkButton" id="button8">
+                    <property name="label">gtk-find</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="use-stock">True</property>
+                    <signal name="clicked" handler="search" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="padding">14</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -646,6 +665,7 @@ Author: Trizen https://github.com/trizen
                                 <child>
                                   <object class="GtkScrolledWindow" id="subsc_scrollwindow">
                                     <property name="can-focus">True</property>
+                                    <property name="margin-top">4</property>
                                     <property name="hscrollbar-policy">never</property>
                                     <child>
                                       <object class="GtkViewport" id="viewport2">
@@ -927,6 +947,7 @@ Author: Trizen https://github.com/trizen
                                   <object class="GtkScrolledWindow" id="scrolledwindow13">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-top">4</property>
                                     <child>
                                       <object class="GtkViewport" id="viewport5">
                                         <property name="visible">True</property>
@@ -936,6 +957,8 @@ Author: Trizen https://github.com/trizen
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
+                                            <property name="spacing">8</property>
+                                            <property name="baseline-position">top</property>
                                             <child>
                                               <object class="GtkFrame" id="frame14">
                                                 <property name="visible">True</property>
@@ -946,7 +969,9 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkAlignment" id="alignment11">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
                                                     <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkBox" id="vbox9">
                                                         <property name="visible">True</property>
@@ -980,6 +1005,7 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkLabel" id="label6">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
                                                     <property name="label" translatable="yes">&lt;b&gt;Type:&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
@@ -1001,7 +1027,9 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkAlignment" id="alignment8">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
                                                     <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkBox" id="vbox11">
                                                         <property name="visible">True</property>
@@ -1035,6 +1063,7 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkLabel" id="label16">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
                                                     <property name="label" translatable="yes">&lt;b&gt;Order by:&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
@@ -1056,7 +1085,9 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkAlignment" id="alignment17">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
                                                     <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkComboBoxText" id="comboboxtext8">
                                                         <property name="visible">True</property>
@@ -1077,6 +1108,7 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkLabel" id="label20">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
                                                     <property name="label" translatable="yes">&lt;b&gt;Duration:&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
@@ -1098,12 +1130,15 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkAlignment" id="alignment14">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
                                                     <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkFlowBox" id="features_flowbox">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="homogeneous">True</property>
+                                                        <property name="column-spacing">2</property>
+                                                        <property name="row-spacing">2</property>
                                                         <property name="selection-mode">none</property>
                                                       </object>
                                                     </child>
@@ -1113,6 +1148,7 @@ Author: Trizen https://github.com/trizen
                                                   <object class="GtkLabel" id="label23">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
                                                     <property name="label" translatable="yes">&lt;b&gt;Video features:&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
@@ -1125,238 +1161,223 @@ Author: Trizen https://github.com/trizen
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkExpander" id="more_options_expander">
+                                              <object class="GtkFrame" id="frame13">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="expanded">True</property>
-                                                <signal name="activate" handler="activate_more_options_expander" swapped="no"/>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0</property>
+                                                <property name="shadow-type">none</property>
                                                 <child>
-                                                  <object class="GtkBox" id="vbox20">
+                                                  <object class="GtkAlignment" id="alignment13">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="orientation">vertical</property>
+                                                    <property name="top-padding">4</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
-                                                      <object class="GtkFrame" id="frame11">
+                                                      <object class="GtkEntry" id="from_author_entry">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label-xalign">0</property>
-                                                        <property name="shadow-type">none</property>
-                                                        <child>
-                                                          <object class="GtkAlignment" id="alignment12">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="left-padding">12</property>
-                                                            <child>
-                                                            <object class="GtkSpinButton" id="spinbutton1">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="tooltip-text" translatable="yes">The maximum number of results per page.</property>
-                                                            <property name="max-length">2</property>
-                                                            <property name="invisible-char">•</property>
-                                                            <property name="caps-lock-warning">False</property>
-                                                            <property name="primary-icon-activatable">False</property>
-                                                            <property name="secondary-icon-activatable">False</property>
-                                                            <property name="adjustment">adjustment1</property>
-                                                            <property name="climb-rate">1</property>
-                                                            <property name="numeric">True</property>
-                                                            <property name="update-policy">if-valid</property>
-                                                            <signal name="activate" handler="search" swapped="no"/>
-                                                            <signal name="value-changed" handler="spin_results_per_page_changed" swapped="no"/>
-                                                            </object>
-                                                            </child>
-                                                          </object>
-                                                        </child>
-                                                        <child type="label">
-                                                          <object class="GtkLabel" id="label19">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;Results per page:&lt;/b&gt;</property>
-                                                            <property name="use-markup">True</property>
-                                                          </object>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkFrame" id="frame9">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label-xalign">0</property>
-                                                        <property name="shadow-type">none</property>
-                                                        <child>
-                                                          <object class="GtkAlignment" id="alignment9">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="left-padding">12</property>
-                                                            <child>
-                                                            <object class="GtkSpinButton" id="spinbutton2">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="tooltip-text" translatable="yes">List videos, starting with a specific page.</property>
-                                                            <property name="invisible-char">•</property>
-                                                            <property name="caps-lock-warning">False</property>
-                                                            <property name="primary-icon-activatable">False</property>
-                                                            <property name="secondary-icon-activatable">False</property>
-                                                            <property name="adjustment">adjustment2</property>
-                                                            <property name="climb-rate">1</property>
-                                                            <property name="numeric">True</property>
-                                                            <property name="update-policy">if-valid</property>
-                                                            <signal name="activate" handler="search" swapped="no"/>
-                                                            <signal name="value-changed" handler="spin_start_with_page_changed" swapped="no"/>
-                                                            </object>
-                                                            </child>
-                                                          </object>
-                                                        </child>
-                                                        <child type="label">
-                                                          <object class="GtkLabel" id="label7">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;Start with page:&lt;/b&gt;</property>
-                                                            <property name="use-markup">True</property>
-                                                          </object>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkFrame" id="frame27">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label-xalign">0</property>
-                                                        <property name="shadow-type">none</property>
-                                                        <child>
-                                                          <object class="GtkAlignment" id="alignment25">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="left-padding">12</property>
-                                                            <child>
-                                                            <object class="GtkBox" id="hbox8">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <child>
-                                                            <object class="GtkComboBoxText" id="comboboxtext1">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="tooltip-text" translatable="yes">Retrieve only videos newer than this.</property>
-                                                            <items>
-                                                            <item id="anytime" translatable="yes">Anytime</item>
-                                                            <item id="hour" translatable="yes">Last hour</item>
-                                                            <item id="today" translatable="yes">Today</item>
-                                                            <item id="week" translatable="yes">This week</item>
-                                                            <item id="month" translatable="yes">This month</item>
-                                                            <item id="year" translatable="yes">This year</item>
-                                                            </items>
-                                                            <signal name="changed" handler="combobox_published_within_changed" swapped="no"/>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">False</property>
-                                                            <property name="pack-type">end</property>
-                                                            <property name="position">1</property>
-                                                            </packing>
-                                                            </child>
-                                                            </object>
-                                                            </child>
-                                                          </object>
-                                                        </child>
-                                                        <child type="label">
-                                                          <object class="GtkLabel" id="label35">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;Upload date:&lt;/b&gt;</property>
-                                                            <property name="use-markup">True</property>
-                                                          </object>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">True</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkFrame" id="frame13">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label-xalign">0</property>
-                                                        <property name="shadow-type">none</property>
-                                                        <child>
-                                                          <object class="GtkAlignment" id="alignment13">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="left-padding">12</property>
-                                                            <child>
-                                                            <object class="GtkEntry" id="from_author_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="tooltip-text" translatable="yes">Search in videos uploaded by a specific author.
+                                                        <property name="can-focus">True</property>
+                                                        <property name="tooltip-text" translatable="yes">Search in videos uploaded by a specific author.
 Unless the author name is valid, this field is ignored.</property>
-                                                            <property name="invisible-char">•</property>
-                                                            <property name="text" translatable="yes">Insert a valid author name...</property>
-                                                            <property name="caps-lock-warning">False</property>
-                                                            <property name="primary-icon-activatable">False</property>
-                                                            <property name="secondary-icon-activatable">False</property>
-                                                            <signal name="activate" handler="search" swapped="no"/>
-                                                            <signal name="button-press-event" handler="clear_text" swapped="no"/>
-                                                            </object>
-                                                            </child>
-                                                          </object>
-                                                        </child>
-                                                        <child type="label">
-                                                          <object class="GtkLabel" id="label17">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;From author:&lt;/b&gt;</property>
-                                                            <property name="use-markup">True</property>
-                                                          </object>
-                                                        </child>
+                                                        <property name="invisible-char">•</property>
+                                                        <property name="text" translatable="yes">Insert a valid author name...</property>
+                                                        <property name="caps-lock-warning">False</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
+                                                        <signal name="activate" handler="search" swapped="no"/>
+                                                        <signal name="button-press-event" handler="clear_text" swapped="no"/>
                                                       </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">3</property>
-                                                      </packing>
                                                     </child>
+                                                  </object>
+                                                </child>
+                                                <child type="label">
+                                                  <object class="GtkLabel" id="label17">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;From author:&lt;/b&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">4</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFrame" id="frame27">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0</property>
+                                                <property name="shadow-type">none</property>
+                                                <child>
+                                                  <object class="GtkAlignment" id="alignment25">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
-                                                      <object class="GtkFrame" id="frame1">
+                                                      <object class="GtkComboBoxText" id="comboboxtext1">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="label-xalign">0</property>
-                                                        <property name="shadow-type">none</property>
+                                                        <property name="tooltip-text" translatable="yes">Retrieve only videos newer than this.</property>
+                                                        <items>
+                                                          <item id="anytime" translatable="yes">Anytime</item>
+                                                          <item id="hour" translatable="yes">Last hour</item>
+                                                          <item id="today" translatable="yes">Today</item>
+                                                          <item id="week" translatable="yes">This week</item>
+                                                          <item id="month" translatable="yes">This month</item>
+                                                          <item id="year" translatable="yes">This year</item>
+                                                        </items>
+                                                        <signal name="changed" handler="combobox_published_within_changed" swapped="no"/>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child type="label">
+                                                  <object class="GtkLabel" id="label35">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Upload date:&lt;/b&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">5</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFrame" id="frame11">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0</property>
+                                                <property name="shadow-type">none</property>
+                                                <child>
+                                                  <object class="GtkAlignment" id="alignment12">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
+                                                    <child>
+                                                      <object class="GtkSpinButton" id="spinbutton1">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="tooltip-text" translatable="yes">The maximum number of results per page.</property>
+                                                        <property name="max-length">2</property>
+                                                        <property name="invisible-char">•</property>
+                                                        <property name="text" translatable="yes">1</property>
+                                                        <property name="caps-lock-warning">False</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
+                                                        <property name="adjustment">adjustment1</property>
+                                                        <property name="climb-rate">1</property>
+                                                        <property name="numeric">True</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="value">1</property>
+                                                        <signal name="activate" handler="search" swapped="no"/>
+                                                        <signal name="value-changed" handler="spin_results_per_page_changed" swapped="no"/>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child type="label">
+                                                  <object class="GtkLabel" id="label19">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Results per page:&lt;/b&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">6</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFrame" id="frame9">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0</property>
+                                                <property name="shadow-type">none</property>
+                                                <child>
+                                                  <object class="GtkAlignment" id="alignment9">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
+                                                    <child>
+                                                      <object class="GtkSpinButton" id="spinbutton2">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="tooltip-text" translatable="yes">List videos, starting with a specific page.</property>
+                                                        <property name="invisible-char">•</property>
+                                                        <property name="text" translatable="yes">1</property>
+                                                        <property name="caps-lock-warning">False</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
+                                                        <property name="adjustment">adjustment2</property>
+                                                        <property name="climb-rate">1</property>
+                                                        <property name="numeric">True</property>
+                                                        <property name="update-policy">if-valid</property>
+                                                        <property name="value">1</property>
+                                                        <signal name="activate" handler="search" swapped="no"/>
+                                                        <signal name="value-changed" handler="spin_start_with_page_changed" swapped="no"/>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                                <child type="label">
+                                                  <object class="GtkLabel" id="label7">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Start with page:&lt;/b&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">6</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFrame" id="frame1">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0</property>
+                                                <property name="shadow-type">none</property>
+                                                <child>
+                                                  <object class="GtkAlignment" id="alignment1">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
+                                                    <child>
+                                                      <object class="GtkFlowBox">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="column-spacing">2</property>
+                                                        <property name="row-spacing">2</property>
+                                                        <property name="selection-mode">none</property>
                                                         <child>
-                                                          <object class="GtkAlignment" id="alignment1">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="left-padding">12</property>
-                                                            <child>
-                                                            <object class="GtkBox" id="vbox10">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="orientation">vertical</property>
-                                                            <child>
-                                                            <object class="GtkCheckButton" id="thumbs_checkbutton">
-                                                            <property name="label" translatable="yes">Show thumbnails</property>
+                                                          <object class="GtkFlowBoxChild">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
-                                                            <property name="receives-default">False</property>
-                                                            <property name="tooltip-text" translatable="yes">Show thumbnails for results.</property>
-                                                            <property name="draw-indicator">True</property>
-                                                            <signal name="toggled" handler="thumbs_checkbutton_toggled" swapped="no"/>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">False</property>
-                                                            <property name="position">0</property>
-                                                            </packing>
-                                                            </child>
                                                             <child>
                                                             <object class="GtkCheckButton" id="fullscreen_checkbutton">
                                                             <property name="label" translatable="yes">Fullscreen mode</property>
@@ -1367,12 +1388,13 @@ Unless the author name is valid, this field is ignored.</property>
                                                             <property name="draw-indicator">True</property>
                                                             <signal name="toggled" handler="toggled_fullscreen" swapped="no"/>
                                                             </object>
-                                                            <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">False</property>
-                                                            <property name="position">1</property>
-                                                            </packing>
                                                             </child>
+                                                          </object>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkFlowBoxChild">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
                                                             <child>
                                                             <object class="GtkCheckButton" id="audio_only_checkbutton">
                                                             <property name="label" translatable="yes">Audio only</property>
@@ -1383,28 +1405,13 @@ Unless the author name is valid, this field is ignored.</property>
                                                             <property name="draw-indicator">True</property>
                                                             <signal name="toggled" handler="toggled_audio_only" swapped="no"/>
                                                             </object>
-                                                            <packing>
-                                                            <property name="expand">True</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">2</property>
-                                                            </packing>
                                                             </child>
-                                                            <child>
-                                                            <object class="GtkCheckButton" id="dash_checkbutton">
-                                                            <property name="label" translatable="yes">DASH videos</property>
+                                                          </object>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkFlowBoxChild">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
-                                                            <property name="receives-default">False</property>
-                                                            <property name="tooltip-text" translatable="yes">Include or exclude streams in DASH format.</property>
-                                                            <property name="draw-indicator">True</property>
-                                                            <signal name="toggled" handler="toggled_dash_support" swapped="no"/>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">False</property>
-                                                            <property name="position">3</property>
-                                                            </packing>
-                                                            </child>
                                                             <child>
                                                             <object class="GtkCheckButton" id="clear_list_checkbutton">
                                                             <property name="label" translatable="yes">Clear search list</property>
@@ -1415,73 +1422,60 @@ Unless the author name is valid, this field is ignored.</property>
                                                             <property name="draw-indicator">True</property>
                                                             <signal name="toggled" handler="toggled_clear_search_list" swapped="no"/>
                                                             </object>
-                                                            <packing>
-                                                            <property name="expand">True</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">4</property>
-                                                            </packing>
                                                             </child>
+                                                          </object>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkFlowBoxChild">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="dash_checkbutton">
+                                                            <property name="label" translatable="yes">DASH videos</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">False</property>
+                                                            <property name="tooltip-text" translatable="yes">Include or exclude streams in DASH format.</property>
+                                                            <property name="draw-indicator">True</property>
+                                                            <signal name="toggled" handler="toggled_dash_support" swapped="no"/>
                                                             </object>
                                                             </child>
                                                           </object>
                                                         </child>
-                                                        <child type="label">
-                                                          <object class="GtkLabel" id="label4">
+                                                        <child>
+                                                          <object class="GtkFlowBoxChild">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;b&gt;Other options:&lt;/b&gt;</property>
-                                                            <property name="use-markup">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="thumbs_checkbutton">
+                                                            <property name="label" translatable="yes">Show thumbnails</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">False</property>
+                                                            <property name="tooltip-text" translatable="yes">Show thumbnails for results.</property>
+                                                            <property name="draw-indicator">True</property>
+                                                            <signal name="toggled" handler="thumbs_checkbutton_toggled" swapped="no"/>
+                                                            </object>
+                                                            </child>
                                                           </object>
                                                         </child>
                                                       </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">5</property>
-                                                      </packing>
                                                     </child>
                                                   </object>
                                                 </child>
                                                 <child type="label">
-                                                  <object class="GtkLabel" id="label32">
+                                                  <object class="GtkLabel" id="label4">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">More options</property>
+                                                    <property name="xpad">4</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Other options:&lt;/b&gt;</property>
+                                                    <property name="use-markup">True</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">7</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkButtonBox" id="hbuttonbox6">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="homogeneous">True</property>
-                                                <property name="layout-style">center</property>
-                                                <child>
-                                                  <object class="GtkButton" id="button8">
-                                                    <property name="label">gtk-find</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
-                                                    <property name="use-stock">True</property>
-                                                    <signal name="clicked" handler="search" swapped="no"/>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="padding">14</property>
                                                 <property name="position">8</property>
                                               </packing>
                                             </child>
@@ -1495,7 +1489,9 @@ Unless the author name is valid, this field is ignored.</property>
                                                   <object class="GtkAlignment" id="alignment10">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="top-padding">4</property>
                                                     <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkComboBoxText" id="comboboxtext9">
                                                         <property name="visible">True</property>
@@ -1523,6 +1519,7 @@ When the specified resolution is not found, the best available resolution is use
                                                   <object class="GtkLabel" id="label18">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
+                                                    <property name="xpad">4</property>
                                                     <property name="label" translatable="yes">&lt;b&gt;Resolution&lt;/b&gt;</property>
                                                     <property name="use-markup">True</property>
                                                   </object>
@@ -1531,8 +1528,7 @@ When the specified resolution is not found, the best available resolution is use
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="pack-type">end</property>
-                                                <property name="position">9</property>
+                                                <property name="position">10</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -1561,7 +1557,10 @@ When the specified resolution is not found, the best available resolution is use
                                   <object class="GtkBox" id="vbox8">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="margin-top">4</property>
                                     <property name="orientation">vertical</property>
+                                    <property name="spacing">8</property>
+                                    <property name="baseline-position">top</property>
                                     <child>
                                       <object class="GtkFrame" id="frame4">
                                         <property name="visible">True</property>
@@ -1572,7 +1571,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment4">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkEntry" id="entry1">
                                                 <property name="visible">True</property>
@@ -1590,6 +1591,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label9">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Uploads:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1598,7 +1600,6 @@ When the specified resolution is not found, the best available resolution is use
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="padding">3</property>
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
@@ -1612,7 +1613,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment23">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkEntry" id="entry3">
                                                 <property name="visible">True</property>
@@ -1630,6 +1633,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label30">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Favorites:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1638,7 +1642,6 @@ When the specified resolution is not found, the best available resolution is use
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="padding">3</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
@@ -1652,7 +1655,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment5">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkEntry" id="entry4">
                                                 <property name="visible">True</property>
@@ -1669,6 +1674,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label34">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Subscriptions:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1690,7 +1696,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment27">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkEntry" id="entry5">
                                                 <property name="visible">True</property>
@@ -1707,6 +1715,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Likes:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1728,7 +1737,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment2">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkEntry" id="entry2">
                                                 <property name="visible">True</property>
@@ -1746,6 +1757,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label5">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Playlists:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1754,7 +1766,6 @@ When the specified resolution is not found, the best available resolution is use
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="padding">3</property>
                                         <property name="position">4</property>
                                       </packing>
                                     </child>
@@ -1769,7 +1780,9 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkAlignment" id="alignment26">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="top-padding">4</property>
                                             <property name="left-padding">12</property>
+                                            <property name="right-padding">12</property>
                                             <child>
                                               <object class="GtkComboBoxText" id="comboboxtext7">
                                                 <property name="visible">True</property>
@@ -1788,6 +1801,7 @@ When the specified resolution is not found, the best available resolution is use
                                           <object class="GtkLabel" id="label36">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xpad">4</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Channel type:&lt;/b&gt;</property>
                                             <property name="use-markup">True</property>
                                           </object>
@@ -1796,7 +1810,6 @@ When the specified resolution is not found, the best available resolution is use
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
                                         <property name="position">5</property>
                                       </packing>
                                     </child>
@@ -1820,6 +1833,7 @@ When the specified resolution is not found, the best available resolution is use
                                   <object class="GtkScrolledWindow" id="scrolledwindow8">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-top">4</property>
                                     <child>
                                       <object class="GtkTreeView" id="treeview3">
                                         <property name="visible">True</property>
@@ -1883,6 +1897,7 @@ When the specified resolution is not found, the best available resolution is use
                                   <object class="GtkScrolledWindow" id="scrolledwindow7">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
+                                    <property name="margin-top">4</property>
                                     <child>
                                       <object class="GtkViewport" id="viewport4">
                                         <property name="visible">True</property>


### PR DESCRIPTION
Include moving the "Find" button next to the search field.

~I've only gone through the "Settings" pane for now, but I can do the same with the "Channel" pane.~

Before:
![before](https://user-images.githubusercontent.com/5104286/184494033-2011ba4c-8e6c-4cc7-a598-fd43b693e5a9.png)

After:
![after](https://user-images.githubusercontent.com/5104286/184494070-a0a66449-f823-499b-b815-0211b0c751fb.png)
