### PR TITLE
gui: fix start page max results controls

### DIFF
--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1282,7 +1282,7 @@ Unless the author name is valid, this field is ignored.</property>
                                                         <property name="numeric">True</property>
                                                         <property name="update-policy">if-valid</property>
                                                         <property name="value">1</property>
-                                                        <signal name="activate" handler="search" swapped="no"/>
+                                                        <signal name="activate" handler="search" after="yes" swapped="no"/>
                                                         <signal name="value-changed" handler="spin_results_per_page_changed" swapped="no"/>
                                                       </object>
                                                     </child>
@@ -1332,7 +1332,7 @@ Unless the author name is valid, this field is ignored.</property>
                                                         <property name="numeric">True</property>
                                                         <property name="update-policy">if-valid</property>
                                                         <property name="value">1</property>
-                                                        <signal name="activate" handler="search" swapped="no"/>
+                                                        <signal name="activate" handler="search" after="yes" swapped="no"/>
                                                         <signal name="value-changed" handler="spin_start_with_page_changed" swapped="no"/>
                                                       </object>
                                                     </child>


### PR DESCRIPTION
The bug:

- focus the start page or / max results widget
- change the value
- press enter to "activate" the widget and initiate a search

 → the new value is not used.