### PR TITLE
overhaul thumbnails handling

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -2691,7 +2691,12 @@ sub get_pixbuf_thumbnail_from_content {
     }
 
     my $pixbuf;
+
     if (defined $thumbnail) {
+
+        # Add/update thumbnails' cache entry.
+        add_thumbnail_to_cache($url, $thumbnail);
+
         my $pixbufloader = 'Gtk3::Gdk::PixbufLoader'->new;
 
         $pixbufloader->signal_connect(
@@ -2707,15 +2712,6 @@ sub get_pixbuf_thumbnail_from_content {
             $pixbufloader->close;
             $pixbuf = $pixbufloader->get_pixbuf;
         };
-    }
-
-    if (defined($pixbuf) and !get_thumbnail_from_cache($url)) {
-
-        my $buffer = eval { pack('C*', @{$pixbuf->save_to_buffer($CONFIG{cache_thumbnails_format})}) };
-
-        if (defined($buffer)) {
-            add_thumbnail_to_cache($url, $buffer);
-        }
     }
 
     $pixbuf //= $default_thumb;

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -2684,8 +2684,16 @@ sub get_pixbuf_thumbnail_from_content {
     if (defined $thumbnail) {
         my $pixbufloader = 'Gtk3::Gdk::PixbufLoader'->new;
 
+        $pixbufloader->signal_connect(
+            'size-prepared' => sub {
+            my ($loader, $width, $height) = @_;
+            my $scale = min($xsize / $width, $ysize / $height);
+            if ($scale < 1.0) {
+                $loader->set_size($width * $scale, $height * $scale);
+            }
+        });
+
         eval {
-            $pixbufloader->set_size($xsize, $ysize);
             $pixbufloader->write($thumbnail);
             $pixbufloader->close;
             $pixbuf = $pixbufloader->get_pixbuf;

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -202,7 +202,7 @@ my %CONFIG = (
     # GUI options
     clear_text_entries_on_click => 0,
     show_thumbs                 => 1,
-    thumbnail_size              => '160x90',
+    thumbnail_size              => '224x126',
     clear_search_list           => 1,
     default_notebook_page       => 1,
     mainw_size                  => '700x400',

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -2653,27 +2653,6 @@ sub append_next_page {
     return $iter;
 }
 
-sub determine_image_format {
-    #
-    ## Code from: https://metacpan.org/release/Image-Info/source/lib/Image/Info.pm
-    #
-
-    local ($_) = @_;
-    return "JPEG" if /^\xFF\xD8/;
-    return "PNG"  if /^\x89PNG\x0d\x0a\x1a\x0a/;
-    return "GIF"  if /^GIF8[79]a/;
-    return "TIFF" if /^MM\x00\x2a/;
-    return "TIFF" if /^II\x2a\x00/;
-    return "BMP"  if /^BM/;
-    return "ICO"  if /^\000\000\001\000/;
-    return "PPM"  if /^P[1-6]/;
-    return "XPM"  if /(^\/\* XPM \*\/)|(static\s+char\s+\*\w+\[\]\s*=\s*{\s*"\d+)/;
-    return "XBM"  if /^(?:\/\*.*\*\/\n)?#define\s/;
-    return "SVG"  if /^(<\?xml|[\012\015\t ]*<svg\b)/;
-    return "WEBP" if /^RIFF.{4}WEBP/s;
-    return undef;
-}
-
 sub lwp_get {
     my ($url) = @_;
 
@@ -2703,22 +2682,13 @@ sub get_pixbuf_thumbnail_from_content {
 
     my $pixbuf;
     if (defined $thumbnail) {
-        my $type = determine_image_format($thumbnail);
-
-        my $pixbufloader;
-        if (defined($type)) {
-            $pixbufloader = eval { 'Gtk3::Gdk::PixbufLoader'->new_with_type(lc($type)) };
-        }
-        if (not defined $pixbufloader) {
-            $pixbufloader = 'Gtk3::Gdk::PixbufLoader'->new;
-        }
+        my $pixbufloader = 'Gtk3::Gdk::PixbufLoader'->new;
 
         eval {
             $pixbufloader->set_size($xsize, $ysize);
-            ## $pixbufloader->write($thumbnail);      # Gtk3 bug?
-            $pixbufloader->write([unpack 'C*', $thumbnail]);
-            $pixbuf = $pixbufloader->get_pixbuf;
+            $pixbufloader->write($thumbnail);
             $pixbufloader->close;
+            $pixbuf = $pixbufloader->get_pixbuf;
         };
     }
 

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -493,6 +493,8 @@ my $feed_icon_pixbuf      = 'Gtk3::Gdk::Pixbuf'->new_from_file_at_size(catfile($
 my $feed_icon_gray_pixbuf = 'Gtk3::Gdk::Pixbuf'->new_from_file_at_size(catfile($icons_path, "feed_gray.png"),     16,  16);
 my $default_thumb         = 'Gtk3::Gdk::Pixbuf'->new_from_file_at_size(catfile($icons_path, "default_thumb.jpg"), 160, 90);
 
+my $webp_supported = any { $_->name eq 'webp' } Gtk3::Gdk::Pixbuf::get_formats;
+
 # Setting application title and icon
 $mainw->set_title("$appname $version");
 $mainw->set_icon($app_icon_pixbuf);
@@ -3157,8 +3159,8 @@ sub get_thumbnail_info {
         # Clean URL of trackers and other junk
         $url =~ s/\.(?:jpg|png|webp)\K\?.*//;
 
-        # Prefer JPEG over WEBP (otherwise, it fails when webp-pixbuf-loader is not installed - #50)
-        $url =~ s/\.webp\z/.jpg/ && $url =~ s{/vi_webp/}{/vi/};
+        # Prefer JPEG format over WebP if the later is not supported.
+        $url =~ s/\.webp\z/.jpg/ && $url =~ s{/vi_webp/}{/vi/} unless $webp_supported;
     }
 
     return ($url, $xsize, $ysize);

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -3168,7 +3168,7 @@ sub set_thumbnail {
     my ($entry, $liststore, $iter) = @_;
 
     my ($url, $xsize, $ysize) = get_thumbnail_info($entry);
-    $liststore->set($iter, [1], [$default_thumb]);
+    $liststore->set($iter, [1, 10, 11], [$default_thumb, $xsize, $ysize]);
 
     Glib::Idle->add(
         sub {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -4274,7 +4274,7 @@ EOT
     $linkbutton->set_uri($url);
 
     # Getting thumbs (start, middle, end).
-    foreach my $nr (1..3) {
+    foreach my $nr ($opt{extra_info} ? () : 1..3) {
 
         my ($url, $xsize, $ysize) = get_thumbnail_info($info);
         my $widget = $gui->get_object("image$nr");

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -202,6 +202,7 @@ my %CONFIG = (
     # GUI options
     clear_text_entries_on_click => 0,
     show_thumbs                 => 1,
+    thumbnail_size              => '160x90',
     clear_search_list           => 1,
     default_notebook_page       => 1,
     mainw_size                  => '700x400',
@@ -238,7 +239,6 @@ my %CONFIG = (
     api_host => "auto",
 
     # URI options
-    thumbnail_type       => 'medium',
     youtube_video_url    => 'https://www.youtube.com/watch?v=%s',
     youtube_playlist_url => 'https://www.youtube.com/playlist?list=%s',
     youtube_channel_url  => 'https://www.youtube.com/channel/%s',
@@ -589,6 +589,9 @@ foreach my $path ($CONFIG{cache_dir}) {
     eval { File::Path::make_path($path) }
       or warn "[!] Can't create path <<$path>>: $!";
 }
+
+# Expected thumbnail size
+my @THUMBNAILS_SIZE = split(/x/i, $CONFIG{thumbnail_size}, 2);
 
 {
     my $split_string = sub {
@@ -2663,11 +2666,18 @@ sub lwp_get {
     return $data;
 }
 
+sub fit_to_dimensions {
+    my ($width, $height, $max_width, $max_height) = @_;
+    my $scale = min($max_width / $width, $max_height / $height);
+    if ($scale < 1.0) {
+        $width *= $scale;
+        $height *= $scale;
+    }
+    return ($width, $height);
+}
+
 sub get_pixbuf_thumbnail_from_content {
     my ($thumbnail, $url, $xsize, $ysize) = @_;
-
-    $xsize //= 160;
-    $ysize //= 90;
 
     $thumbnail // return $default_thumb;
 
@@ -2687,10 +2697,9 @@ sub get_pixbuf_thumbnail_from_content {
         $pixbufloader->signal_connect(
             'size-prepared' => sub {
             my ($loader, $width, $height) = @_;
-            my $scale = min($xsize / $width, $ysize / $height);
-            if ($scale < 1.0) {
-                $loader->set_size($width * $scale, $height * $scale);
-            }
+            my ($fit_width, $fit_height) = fit_to_dimensions($width, $height, $xsize, $ysize);
+            my $resized = $fit_width != $width || $fit_height != $height;
+            $loader->set_size($fit_width, $fit_height) if $resized;
         });
 
         eval {
@@ -2758,18 +2767,6 @@ sub get_pixbuf_thumbnail_from_url {
     }
 
     my $pixbuf = get_pixbuf_thumbnail_from_content($thumbnail, $url, $xsize, $ysize);
-
-    return $pixbuf;
-}
-
-sub get_pixbuf_thumbnail_from_entry {
-    my ($entry) = @_;
-
-    my $thumbnail_url  = $yv_utils->get_thumbnail_url($entry, $CONFIG{thumbnail_type});
-    my $thumbnail_data = $entry->{_thumbnail_data} // get_thumbnail_from_cache($thumbnail_url) // lwp_get($thumbnail_url);
-
-    my $square_format = $yv_utils->is_channel($entry) || $yv_utils->is_subscription($entry);
-    my $pixbuf        = get_pixbuf_thumbnail_from_content($thumbnail_data, $thumbnail_url, ($square_format ? (160, 160) : ()));
 
     return $pixbuf;
 }
@@ -3150,15 +3147,37 @@ sub set_entry_tooltip {
     $liststore->set($iter, [9], ["<b>" . encode_entities($title) . "</b>" . "\n\n" . encode_entities($description)]);
 }
 
+sub get_thumbnail_info {
+    my ($entry) = @_;
+
+    my ($xsize, $ysize) = @THUMBNAILS_SIZE;
+    my $thumb = $yv_utils->get_thumbnail($entry, $xsize, $ysize);
+
+    ($xsize, $ysize) = fit_to_dimensions($thumb->{width}, $thumb->{height}, $xsize, $ysize);
+
+    my $url = $thumb->{url};
+
+    if (defined $url) {
+        # Clean URL of trackers and other junk
+        $url =~ s/\.(?:jpg|png|webp)\K\?.*//;
+
+        # Prefer JPEG over WEBP (otherwise, it fails when webp-pixbuf-loader is not installed - #50)
+        $url =~ s/\.webp\z/.jpg/ && $url =~ s{/vi_webp/}{/vi/};
+    }
+
+    return ($url, $xsize, $ysize);
+}
+
 sub set_thumbnail {
     my ($entry, $liststore, $iter) = @_;
 
+    my ($url, $xsize, $ysize) = get_thumbnail_info($entry);
     $liststore->set($iter, [1], [$default_thumb]);
 
     Glib::Idle->add(
         sub {
             my ($entry, $liststore, $iter) = @{$_[0]};
-            my $pixbuf = get_pixbuf_thumbnail_from_entry($entry);
+            my $pixbuf = get_pixbuf_thumbnail_from_url($url, $xsize, $ysize);
             $liststore->set($iter, [1], [$pixbuf]);
             return 0;
         },
@@ -4256,45 +4275,29 @@ EOT
     $linkbutton->set_label($url);
     $linkbutton->set_uri($url);
 
-    my %thumbs = (
-                  start  => 1,
-                  middle => 2,
-                  end    => 3,
-                 );
+    # Getting thumbs (start, middle, end).
+    foreach my $nr (1..3) {
 
-    # Getting thumbs
-    foreach my $nr (keys %thumbs) {
+        my ($url, $xsize, $ysize) = get_thumbnail_info($info);
+        my $widget = $gui->get_object("image$nr");
+        $widget->set_size_request($xsize, $ysize);
+        $widget->set_from_pixbuf($default_thumb);
 
-        $gui->get_object("image$thumbs{$nr}")->set_from_pixbuf($default_thumb);
+        if ($url =~ /_live\.\w+\z/) {
+            ## no extra thumbnails available while video is LIVE
+        }
+        else {
+            $url =~ s{/(\w*)default\.(\w+)\z}{/$1$nr.$2};
+        }
 
         Glib::Idle->add(
             sub {
-                my ($nr) = @{$_[0]};
-
-                my $url = $yv_utils->get_thumbnail_url($info, $nr);
-
-                #~ my $thumbnail = $info->{snippet}{thumbnails}{medium};
-                #~ my $url       = $thumbnail->{url};
-
-                if ($url =~ /_live\.\w+\z/) {
-                    ## no extra thumbnails available while video is LIVE
-                }
-                else {
-                    $url =~ s{/\w+\.(\w+)\z}{/mq$thumbs{$nr}.$1};
-                }
-
-                my ($size_x, $size_y) = (160, 90);
-
-                if ($type eq 'subscription' or $type eq 'channel') {
-                    ($size_x, $size_y) = (120, 120);
-                }
-
-                my $pixbuf = get_pixbuf_thumbnail_from_url($url, $size_x, $size_y);
-                $gui->get_object("image$thumbs{$nr}")->set_from_pixbuf($pixbuf);
-
+                my ($widget, $url, $xsize, $ysize) = @{$_[0]};
+                my $pixbuf = get_pixbuf_thumbnail_from_url($url, $xsize, $ysize);
+                $widget->set_from_pixbuf($pixbuf);
                 return 0;
             },
-            [$nr],
+            [$widget, $url, $xsize, $ysize],
             Glib::G_PRIORITY_LOW
         );
     }

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -3146,9 +3146,11 @@ sub set_entry_tooltip {
 }
 
 sub get_thumbnail_info {
-    my ($entry) = @_;
+    my ($entry, $xsize, $ysize) = @_;
 
-    my ($xsize, $ysize) = @THUMBNAILS_SIZE;
+    unless ($xsize && $ysize) {
+        ($xsize, $ysize) = @THUMBNAILS_SIZE;
+    }
     my $thumb = $yv_utils->get_thumbnail($entry, $xsize, $ysize);
 
     ($xsize, $ysize) = fit_to_dimensions($thumb->{width}, $thumb->{height}, $xsize, $ysize);
@@ -4273,31 +4275,34 @@ EOT
     $linkbutton->set_label($url);
     $linkbutton->set_uri($url);
 
-    # Getting thumbs (start, middle, end).
-    foreach my $nr ($opt{extra_info} ? () : 1..3) {
+    if ($opt{extra_info}) {
 
-        my ($url, $xsize, $ysize) = get_thumbnail_info($info);
-        my $widget = $gui->get_object("image$nr");
-        $widget->set_size_request($xsize, $ysize);
-        $widget->set_from_pixbuf($default_thumb);
+        # Getting thumbs (start, middle, end).
+        foreach my $nr (1..3) {
 
-        if ($url =~ /_live\.\w+\z/) {
-            ## no extra thumbnails available while video is LIVE
+            my ($url, $xsize, $ysize) = get_thumbnail_info($info, 320, 180);
+            my $widget = $gui->get_object("image$nr");
+            $widget->set_size_request($xsize, $ysize);
+            $widget->set_from_pixbuf($default_thumb);
+
+            if ($url =~ /_live\.\w+\z/) {
+                ## no extra thumbnails available while video is LIVE
+            }
+            else {
+                $url =~ s{/(\w*)default\.(\w+)\z}{/$1$nr.$2};
+            }
+
+            Glib::Idle->add(
+                sub {
+                    my ($widget, $url, $xsize, $ysize) = @{$_[0]};
+                    my $pixbuf = get_pixbuf_thumbnail_from_url($url, $xsize, $ysize);
+                    $widget->set_from_pixbuf($pixbuf);
+                    return 0;
+                },
+                [$widget, $url, $xsize, $ysize],
+                Glib::G_PRIORITY_LOW
+            );
         }
-        else {
-            $url =~ s{/(\w*)default\.(\w+)\z}{/$1$nr.$2};
-        }
-
-        Glib::Idle->add(
-            sub {
-                my ($widget, $url, $xsize, $ysize) = @{$_[0]};
-                my $pixbuf = get_pixbuf_thumbnail_from_url($url, $xsize, $ysize);
-                $widget->set_from_pixbuf($pixbuf);
-                return 0;
-            },
-            [$widget, $url, $xsize, $ysize],
-            Glib::G_PRIORITY_LOW
-        );
     }
 
     # Setting textview description

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -318,8 +318,8 @@ sub set_lwp_useragent {
                  # don't cache if "cache-control" specifies "max-age=0", "no-store" or "no-cache"
                  or (($response->header('cache-control') // '') =~ /\b(?:max-age=0|no-store|no-cache)\b/)
 
-                 # don't cache video or audio files
-                 or (($response->header('content-type') // '') =~ /\b(?:video|audio)\b/);
+                 # don't cache media content
+                 or (($response->header('content-type') // '') =~ /\b(?:audio|image|video)\b/);
            },
 
            recache_if => sub {

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -2080,50 +2080,40 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
     <property name="title" translatable="yes">Extra details</property>
     <property name="modal">True</property>
     <property name="window-position">center-on-parent</property>
-    <property name="default-height">400</property>
+    <property name="default-width">800</property>
+    <property name="default-height">600</property>
     <property name="destroy-with-parent">True</property>
     <property name="gravity">static</property>
     <property name="transient-for">__MAIN__</property>
+    <property name="has-resize-grip">True</property>
     <signal name="delete-event" handler="hide_details_window" swapped="no"/>
     <signal name="destroy" handler="hide_details_window" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox4">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-start">4</property>
+        <property name="margin-end">4</property>
+        <property name="margin-top">4</property>
+        <property name="margin-bottom">4</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">4</property>
         <child>
-          <object class="GtkBox" id="vbox">
+          <object class="GtkLabel" id="video_title_label">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkLabel" id="video_title_label">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Details window label</property>
-                <property name="use-markup">True</property>
-                <property name="justify">fill</property>
-                <property name="selectable">True</property>
-                <property name="ellipsize">end</property>
-                <property name="track-visited-links">False</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparator" id="hseparator3">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
+            <property name="margin-left">4</property>
+            <property name="margin-right">4</property>
+            <property name="margin-start">4</property>
+            <property name="margin-end">4</property>
+            <property name="margin-top">4</property>
+            <property name="margin-bottom">4</property>
+            <property name="label" translatable="yes">Details window label</property>
+            <property name="use-markup">True</property>
+            <property name="justify">fill</property>
+            <property name="selectable">True</property>
+            <property name="ellipsize">end</property>
+            <property name="track-visited-links">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -2132,33 +2122,50 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox13">
+          <object class="GtkSeparator" id="hseparator3">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkPaned" id="vpaned1">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
             <child>
-              <object class="GtkBox" id="vbox18">
+              <object class="GtkScrolledWindow" id="scrolledwindow14">
+                <property name="width-request">320</property>
+                <property name="height-request">540</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="orientation">vertical</property>
+                <property name="can-focus">True</property>
+                <property name="margin-right">4</property>
+                <property name="margin-end">4</property>
+                <property name="margin-bottom">4</property>
                 <child>
-                  <object class="GtkBox" id="vbox24">
+                  <object class="GtkViewport">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="orientation">vertical</property>
+                    <property name="shadow-type">none</property>
                     <child>
-                      <object class="GtkBox" id="hbox16">
+                      <object class="GtkBox" id="vbox252">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+                        <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkImage" id="image1">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                         <child>
@@ -2167,9 +2174,9 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                             <property name="can-focus">False</property>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -2178,128 +2185,35 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                             <property name="can-focus">False</property>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
                             <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSeparator" id="hseparator2">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkPaned" id="vpaned1">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="video_details_label">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="use-markup">True</property>
-                        <property name="wrap">True</property>
-                        <property name="selectable">True</property>
-                        <property name="ellipsize">end</property>
-                      </object>
-                      <packing>
-                        <property name="resize">False</property>
-                        <property name="shrink">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkFrame" id="frame3">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label-xalign">0</property>
-                        <property name="shadow-type">out</property>
-                        <child>
-                          <object class="GtkAlignment" id="alignment3">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="left-padding">12</property>
-                            <child>
-                              <object class="GtkScrolledWindow" id="scrolledwindow4">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <child>
-                                  <object class="GtkTextView" id="description_textview">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="pixels-below-lines">2</property>
-                                    <property name="wrap-mode">word</property>
-                                    <property name="accepts-tab">False</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label8">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Description</property>
-                            <attributes>
-                              <attribute name="style" value="normal"/>
-                              <attribute name="weight" value="bold"/>
-                              <attribute name="variant" value="normal"/>
-                              <attribute name="stretch" value="ultra-condensed"/>
-                              <attribute name="scale" value="1.3"/>
-                            </attributes>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="resize">True</property>
-                        <property name="shrink">True</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="resize">False</property>
+                <property name="shrink">True</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButtonBox" id="hbuttonbox10">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="layout-style">center</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLinkButton" id="linkbutton1">
+                  <object class="GtkLabel" id="video_details_label">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="relief">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                    <property name="ellipsize">end</property>
+                    <property name="width-chars">35</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -2307,24 +2221,118 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                     <property name="position">0</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkSeparator">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">4</property>
+                    <property name="margin-right">4</property>
+                    <property name="margin-start">4</property>
+                    <property name="margin-end">4</property>
+                    <property name="margin-top">4</property>
+                    <property name="margin-bottom">4</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">out</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow4">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="margin-left">8</property>
+                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
+                        <property name="margin-top">4</property>
+                        <property name="margin-bottom">4</property>
+                        <child>
+                          <object class="GtkTextView" id="description_textview">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="pixels-below-lines">2</property>
+                            <property name="wrap-mode">word</property>
+                            <property name="left-margin">4</property>
+                            <property name="right-margin">4</property>
+                            <property name="accepts-tab">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label8">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Description</property>
+                        <attributes>
+                          <attribute name="style" value="normal"/>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="variant" value="normal"/>
+                          <attribute name="stretch" value="ultra-condensed"/>
+                          <attribute name="scale" value="1.3"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="resize">True</property>
+                <property name="shrink">True</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox" id="hbuttonbox10">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">center</property>
+            <child>
+              <object class="GtkLinkButton" id="linkbutton1">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox2">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="spacing">8</property>
+            <property name="homogeneous">True</property>
+            <property name="layout-style">center</property>
             <child>
               <object class="GtkButton" id="play">
                 <property name="label">gtk-media-play</property>
@@ -2374,8 +2382,8 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -222,6 +222,10 @@ Author: Trizen https://github.com/trizen
       <column type="gchararray"/>
       <!-- column-name tooltip -->
       <column type="gchararray"/>
+      <!-- column-name pic_width -->
+      <column type="guint"/>
+      <!-- column-name pic_height -->
+      <column type="guint"/>
     </columns>
   </object>
   <object class="GtkListStore" id="liststore11">
@@ -592,6 +596,8 @@ Author: Trizen https://github.com/trizen
                         <child>
                           <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
                           <attributes>
+                            <attribute name="width">10</attribute>
+                            <attribute name="height">11</attribute>
                             <attribute name="pixbuf">1</attribute>
                           </attributes>
                         </child>


### PR DESCRIPTION
The gist of it: slightly bigger thumbnails (no use wasting space), no upscaling, keep aspect-ratio when downscaling, better cache handling, and the `thumbnail_type       => 'medium',` settings is now `thumbnail_size              => '224x126'` (with correct support for bigger sizes).