### PR TITLE
cleanup channel related features

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -1414,16 +1414,6 @@ sub get_treeview_popup_menu {
             $author->append($item);
         }
 
-        # Favorites of this author
-        {
-            my $item = 'Gtk3::ImageMenuItem'->new("Favorites");
-            $item->signal_connect(activate => sub { favorites('channel', $channel_id) });
-            $item->set_property(tooltip_text => "Show favorite videos of this author");
-            $item->set_image('Gtk3::Image'->new_from_icon_name("emblem-favorite-symbolic", q{menu}));
-            $item->show;
-            $author->append($item);
-        }
-
         # Separator
         {
             my $item = 'Gtk3::SeparatorMenuItem'->new;
@@ -1625,7 +1615,6 @@ set_text(
     CTRL+W : show the watched videos
     CTRL+U : show the saved user-list
     CTRL+D : show more details for a selected entry
-    CTRL+G : show favorite videos of the author of a selected video
     CTRL+R : show related videos for a selected video
     CTRL+M : show videos from the author of a selected video
     CTRL+K : show playlists from the author of a selected video
@@ -1655,7 +1644,6 @@ $accel->connect(ord('d'), ['control-mask'], ['visible'], \&show_details_window);
 #$accel->connect(ord('c'), ['control-mask'], ['visible'], \&show_comments_window);
 $accel->connect(ord('s'), ['control-mask'], ['visible'], \&add_user_to_favorites);
 $accel->connect(ord('r'), ['control-mask'], ['visible'], \&show_related_videos);
-$accel->connect(ord('g'), ['control-mask'], ['visible'], \&show_user_favorite_videos);
 $accel->connect(ord('m'), ['control-mask'], ['visible'], \&show_videos_from_selected_author);
 $accel->connect(ord('k'), ['control-mask'], ['visible'], \&show_playlists_from_selected_author);
 $accel->connect(0xffff,   ['lock-mask'],    ['visible'], \&delete_selected_row);
@@ -2198,7 +2186,7 @@ sub popular_uploads {
 
 {
     no strict 'refs';
-    foreach my $name (qw(favorites uploads playlists)) {
+    foreach my $name (qw(uploads playlists)) {
         *{__PACKAGE__ . '::' . $name} = sub {
             my ($type, $channel) = @_;
 
@@ -3145,11 +3133,6 @@ sub list_username_playlists {
     return;
 }
 
-sub favorites_from_text_entry {
-    my ($text_entry) = @_;
-    favorites($channel_type_combobox->get_active_text, $text_entry->get_text);
-}
-
 sub uploads_from_text_entry {
     my ($text_entry) = @_;
     uploads($channel_type_combobox->get_active_text, $text_entry->get_text);
@@ -3575,11 +3558,6 @@ sub comments_row_activated {
     open_external_url($comment_url);
 
     return 1;
-}
-
-sub show_user_favorite_videos {
-    my $username = get_channel_id_for_selected_video() // return;
-    favorites('channel', $username);
 }
 
 sub get_channel_id_for_selected_video {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -2210,7 +2210,7 @@ sub popular_uploads {
 
 {
     no strict 'refs';
-    foreach my $name (qw(favorites uploads likes playlists subscriptions)) {
+    foreach my $name (qw(favorites uploads likes playlists)) {
         *{__PACKAGE__ . '::' . $name} = sub {
             my ($type, $channel) = @_;
 
@@ -3175,11 +3175,6 @@ sub playlists_from_text_entry {
 sub likes_from_text_entry {
     my ($text_entry) = @_;
     likes($channel_type_combobox->get_active_text, $text_entry->get_text);
-}
-
-sub subscriptions_from_text_entry {
-    my ($text_entry) = @_;
-    subscriptions($channel_type_combobox->get_active_text, $text_entry->get_text);
 }
 
 sub strip_spaces {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -176,9 +176,6 @@ my %symbols = (
 # Main configuration
 my %CONFIG = (
 
-    # Combobox values
-    active_channel_type_combobox        => 0,
-
     video_players => {
                       vlc => {
                               cmd   => q{vlc},
@@ -390,7 +387,6 @@ my %objects = (
     'comboboxtext8'          => \my $duration_combobox,
     'comboboxtext1'          => \my $published_within_combobox,
     'comboboxtext2'          => \my $order_combobox,
-    'comboboxtext7'          => \my $channel_type_combobox,
     'comboboxtext10'         => \my $search_for_combobox,
     'spinbutton1'            => \my $spin_results,
     'spinbutton2'            => \my $spin_start_with_page,
@@ -1005,7 +1001,6 @@ sub apply_configuration {
     $dash_checkbutton->set_active($CONFIG{dash});
 
     $clear_list_checkbutton->set_active($CONFIG{clear_search_list});
-    $channel_type_combobox->set_active($CONFIG{active_channel_type_combobox});
 
     foreach my $option_name (
                              qw(
@@ -1801,10 +1796,6 @@ sub combobox_resolution_changed {
 
 sub combobox_duration_changed {
     combobox_changed($duration_combobox, "videoDuration", 1);
-}
-
-sub combobox_channel_type_changed {
-    $CONFIG{active_channel_type_combobox} = $channel_type_combobox->get_active;
 }
 
 sub combobox_published_within_changed {
@@ -3135,12 +3126,12 @@ sub list_username_playlists {
 
 sub uploads_from_text_entry {
     my ($text_entry) = @_;
-    uploads($channel_type_combobox->get_active_text, $text_entry->get_text);
+    list_channel_videos($text_entry->get_text);
 }
 
 sub playlists_from_text_entry {
     my ($text_entry) = @_;
-    playlists($channel_type_combobox->get_active_text, $text_entry->get_text);
+    list_channel_playlists($text_entry->get_text);
 }
 
 sub strip_spaces {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -1978,8 +1978,7 @@ sub set_usernames {
                               $iter,
                               0 => $channel,
                               1 => $channels{$channel},
-                              2 => 'channel',
-                              3 => (
+                              2 => (
                                     exists($subscribed_channels{$channel})
                                     ? $feed_icon_pixbuf
                                     : $user_icon_pixbuf
@@ -2079,11 +2078,11 @@ sub subscribe_toggle_selected_username {
 
     if (exists $subscribed_channels{$channel_id}) {
         delete $subscribed_channels{$channel_id};
-        $users_liststore->set($iter, [3], [$user_icon_pixbuf]);
+        $users_liststore->set($iter, [2], [$user_icon_pixbuf]);
     }
     else {
         $subscribed_channels{$channel_id} = $channel_name;
-        $users_liststore->set($iter, [3], [$feed_icon_pixbuf]);
+        $users_liststore->set($iter, [2], [$feed_icon_pixbuf]);
     }
 
     write_channels_to_file(\%subscribed_channels, $CONFIG{subscribed_channels_file});
@@ -2137,20 +2136,18 @@ sub playlists_from_selected_username {
     my $selection = $users_treeview->get_selection() // return;
     my $iter      = $selection->get_selected()       // return;
 
-    my $type    = $users_liststore->get($iter, 2);
     my $channel = $users_liststore->get($iter, 0);
 
-    playlists($type, $channel);
+    playlists('channel', $channel);
 }
 
 sub videos_from_selected_username {
     my $selection = $users_treeview->get_selection() // return;
     my $iter      = $selection->get_selected()       // return;
 
-    my $type    = $users_liststore->get($iter, 2);
     my $channel = $users_liststore->get($iter, 0);
 
-    uploads($type, $channel);
+    uploads('channel', $channel);
 }
 
 sub videos_from_saved_channel {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -1382,7 +1382,7 @@ sub get_treeview_popup_menu {
         # Recent uploads from this author
         {
             my $item = 'Gtk3::ImageMenuItem'->new("Uploads");
-            $item->signal_connect(activate => sub { uploads('channel', $channel_id) });
+            $item->signal_connect(activate => sub { list_channel_videos($channel_id) });
             $item->set_property(tooltip_text => "Show the most recent videos from this author");
             $item->set_image('Gtk3::Image'->new_from_icon_name("emblem-shared-symbolic", q{menu}));
             $item->show;
@@ -2135,19 +2135,13 @@ sub save_usernames_to_file {
 sub playlists_from_selected_username {
     my $selection = $users_treeview->get_selection() // return;
     my $iter      = $selection->get_selected()       // return;
-
-    my $channel = $users_liststore->get($iter, 0);
-
-    playlists('channel', $channel);
+    list_channel_playlists($users_liststore->get($iter, 0));
 }
 
 sub videos_from_selected_username {
     my $selection = $users_treeview->get_selection() // return;
     my $iter      = $selection->get_selected()       // return;
-
-    my $channel = $users_liststore->get($iter, 0);
-
-    uploads('channel', $channel);
+    list_channel_videos($users_liststore->get($iter, 0));
 }
 
 sub videos_from_saved_channel {
@@ -2169,42 +2163,6 @@ sub popular_uploads {
     }
     else {
         die "No popular uploads for channel: <<$channel>>\n";
-    }
-}
-
-{
-    no strict 'refs';
-    foreach my $name (qw(uploads playlists)) {
-        *{__PACKAGE__ . '::' . $name} = sub {
-            my ($type, $channel) = @_;
-
-            my $method = $name;
-
-            if ($yv_utils->is_channelID($channel)) {
-                $method = $name;
-            }
-            elsif ($type =~ /^user/i and $channel ne 'mine' and $channel =~ /^\S+\z/) {
-                $method = $name . '_from_username';
-            }
-            elsif ($type =~ /^channel/i and $channel ne 'mine' and $channel =~ /^\S+\z/) {
-                $method = $name . '_from_username';
-            }
-
-            my $request = $yv_obj->$method(
-                                           ($type =~ /^(user|channel)/i and $channel =~ /^\S+\z/)
-                                           ? $channel
-                                           : ()
-                                          );
-
-            if ($yv_utils->has_entries($request)) {
-                display_results($request);
-            }
-            else {
-                die "No $name results" . ($channel ? " for channel: <<$channel>>\n" : "\n");
-            }
-
-            return 1;
-        };
     }
 }
 
@@ -2243,10 +2201,10 @@ sub check_keywords {
         list_channel_videos($+{channel_id});
     }
     elsif ($key =~ /$get_username_playlists_re/) {
-        list_username_playlists($+{username});
+        list_channel_playlists($+{username});
     }
     elsif ($key =~ /$get_username_videos_re/) {
-        list_username_videos($+{username});
+        list_channel_videos($+{username});
     }
     else {
         return;
@@ -2325,7 +2283,7 @@ sub get_code {
                 list_playlist($code);
             }
             elsif ($type eq 'channel') {
-                uploads('channel', $code);
+                list_channel_videos($code);
             }
             elsif ($type eq 'next_page' and $code ne '') {
 
@@ -3062,61 +3020,31 @@ sub list_playlist {
 }
 
 sub list_channel_videos {
-    my ($channel_id) = @_;
+    my ($channel) = @_;
 
-    my $results = $yv_obj->uploads($channel_id);
-
-    if ($yv_utils->has_entries($results)) {
-        display_results($results);
-        return 1;
-    }
-    else {
-        die "[!] No videos for channel ID: $channel_id\n";
-    }
-    return;
-}
-
-sub list_username_videos {
-    my ($username) = @_;
-
-    my $results = $yv_obj->uploads_from_username($username);
+    my $results = $yv_obj->uploads($channel);
 
     if ($yv_utils->has_entries($results)) {
         display_results($results);
         return 1;
     }
     else {
-        die "[!] No videos for user: $username\n";
+        die "[!] No videos for channel: $channel\n";
     }
     return;
 }
 
 sub list_channel_playlists {
-    my ($channel_id) = @_;
+    my ($channel) = @_;
 
-    my $results = $yv_obj->playlists($channel_id);
-
-    if ($yv_utils->has_entries($results)) {
-        display_results($results);
-        return 1;
-    }
-    else {
-        die "[!] No playlists for channel ID: $channel_id\n";
-    }
-    return;
-}
-
-sub list_username_playlists {
-    my ($username) = @_;
-
-    my $results = $yv_obj->playlists_from_username($username);
+    my $results = $yv_obj->playlists($channel);
 
     if ($yv_utils->has_entries($results)) {
         display_results($results);
         return 1;
     }
     else {
-        die "[!] No playlists for user: $username\n";
+        die "[!] No playlists for channel: $channel\n";
     }
     return;
 }
@@ -3778,18 +3706,11 @@ sub set_prev_next_results_sensitivity {
 }
 
 sub show_videos_from_selected_author {
-    uploads('channel', get_channel_id_for_selected_video() || return);
+    list_channel_videos(get_channel_id_for_selected_video() || return);
 }
 
 sub show_playlists_from_selected_author {
-    my $request = $yv_obj->playlists(get_channel_id_for_selected_video() || return);
-    if ($yv_utils->has_entries($request)) {
-        display_results($request);
-    }
-    else {
-        die "No playlists found...\n";
-    }
-    return 1;
+    list_channel_playlists(get_channel_id_for_selected_video() || return);
 }
 
 sub set_entry_details {

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -1424,18 +1424,6 @@ sub get_treeview_popup_menu {
             $author->append($item);
         }
 
-        # Liked videos by this author
-#<<<
-        #~ {
-            #~ my $item = 'Gtk3::ImageMenuItem'->new("Likes");
-            #~ $item->signal_connect(activate => sub { likes('channel', $channel_id) });
-            #~ $item->set_property(tooltip_text => "Show liked videos by this author");
-            #~ $item->set_image('Gtk3::Image'->new_from_icon_name("emblem-default-symbolic", q{menu}));
-            #~ $item->show;
-            #~ $author->append($item);
-        #~ }
-#>>>
-
         # Separator
         {
             my $item = 'Gtk3::SeparatorMenuItem'->new;
@@ -2210,7 +2198,7 @@ sub popular_uploads {
 
 {
     no strict 'refs';
-    foreach my $name (qw(favorites uploads likes playlists)) {
+    foreach my $name (qw(favorites uploads playlists)) {
         *{__PACKAGE__ . '::' . $name} = sub {
             my ($type, $channel) = @_;
 
@@ -3170,11 +3158,6 @@ sub uploads_from_text_entry {
 sub playlists_from_text_entry {
     my ($text_entry) = @_;
     playlists($channel_type_combobox->get_active_text, $text_entry->get_text);
-}
-
-sub likes_from_text_entry {
-    my ($text_entry) = @_;
-    likes($channel_type_combobox->get_active_text, $text_entry->get_text);
 }
 
 sub strip_spaces {

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -1364,9 +1364,7 @@ sub apply_configuration {
 
         if ($str) {
             if (my $id = extract_channel_id($str)) {
-                $yv_utils->is_channelID($id)
-                  ? print_videos($yv_obj->uploads($id))
-                  : print_videos($yv_obj->uploads_from_username($id));
+                print_videos($yv_obj->uploads($id));
             }
             else {
                 warn_invalid("username or channel ID", $str);
@@ -1413,9 +1411,7 @@ sub apply_configuration {
 
         if ($str) {
             if (my $id = extract_channel_id($str)) {
-                $yv_utils->is_channelID($id)
-                  ? print_playlists($yv_obj->playlists($id))
-                  : print_playlists($yv_obj->playlists_from_username($id));
+                print_playlists($yv_obj->playlists($id));
             }
             else {
                 warn_invalid("username or channel ID", $str);
@@ -2081,10 +2077,10 @@ sub youtube_urls {
         print_videos($yv_obj->uploads($+{channel_id}));
     }
     elsif ($arg =~ /$get_username_playlists_re/) {
-        print_playlists($yv_obj->playlists_from_username($+{username}));
+        print_playlists($yv_obj->playlists($+{username}));
     }
     elsif ($arg =~ /$get_username_videos_re/) {
-        print_videos($yv_obj->uploads_from_username($+{username}));
+        print_videos($yv_obj->uploads($+{username}));
     }
     else {
         return;

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -761,7 +761,6 @@ usage: $execname [options] ([url] | [keywords])
  * Videos
    -uv --uploads=s      : list videos uploaded by a specific channel or user
    -pv --popular=s      : list the most popular videos from a specific channel
-   -uf --favorites=s    : list the favorite videos of a specific user
    -id --videoids=s,s   : play YouTube videos by their IDs
    -rv --related=s      : show related videos for a video ID or URL
    -sv --search-videos  : search for YouTube videos (default mode)
@@ -1096,9 +1095,6 @@ Results: search for 'cats' videos, ordered by ViewCount and short duration.
 Command: $execname -sc math lessons
 Results: search for YouTube channels.
 
-Command: $execname -uf=Google
-Results: show the latest favorite videos by a user.
-
 
 ==== USER INPUT EXAMPLES ====
 
@@ -1431,22 +1427,8 @@ sub apply_configuration {
         }
     }
 
-    if (defined $opt->{favorites}) {
-        my $str = delete($opt->{favorites});
-
-        if ($str) {
-            if (my $id = extract_channel_id($str)) {
-                $yv_utils->is_channelID($id)
-                  ? print_videos($yv_obj->favorites($id))
-                  : print_videos($yv_obj->favorites_from_username($id));
-            }
-            else {
-                warn_invalid("username or channel ID", $str);
-            }
-        }
-        else {
-            print_favorite_videos();
-        }
+    if (defined delete $opt->{favorites}) {
+        print_favorite_videos();
     }
 
     if (defined delete $opt->{likes}) {
@@ -1531,7 +1513,7 @@ sub parse_arguments {
         'search-movie|movies|sm!'      => \$opt{search_movies},
 
         'uploads|U|user|user-videos|uv|u=s' => \$opt{uploads},
-        'favorites|F|user-favorites|uf:s'   => \$opt{favorites},
+        'favorites|F'                       => \$opt{favorites},
         'playlists|P|user-playlists|up:s'   => \$opt{playlists},
         'likes|L|user-likes'                => \$opt{likes},
         'dislikes|D'                        => \$opt{dislikes},

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -2683,7 +2683,7 @@ sub print_comments {
             ## ok
         }
         elsif (valid_num($key, $comments)) {
-            print_videos($yv_obj->get_videos_from_username($comments->[$key - 1]{author}));
+            print_videos($yv_obj->uploads($comments->[$key - 1]{authorId}));
         }
         else {
             warn_invalid('keyword', $key);

--- a/lib/WWW/PipeViewer/Channels.pm
+++ b/lib/WWW/PipeViewer/Channels.pm
@@ -23,7 +23,13 @@ sub _make_channels_url {
     return $self->_make_feed_url('channels', %opts);
 }
 
-sub videos_from_channel_id {
+=head2 uploads($channel_id)
+
+Get the uploads for a given channel ID.
+
+=cut
+
+sub uploads {
     my ($self, $channel_id) = @_;
 
     if (my $results = $self->yt_channel_uploads($channel_id)) {
@@ -32,11 +38,6 @@ sub videos_from_channel_id {
 
     my $url = $self->_make_feed_url("channels/$channel_id/videos");
     return $self->_get_results($url);
-}
-
-sub videos_from_username {
-    my ($self, $channel_id) = @_;
-    $self->videos_from_channel_id($channel_id);
 }
 
 =head2 popular_videos($channel_id)

--- a/lib/WWW/PipeViewer/Channels.pm
+++ b/lib/WWW/PipeViewer/Channels.pm
@@ -12,7 +12,7 @@ WWW::PipeViewer::Channels - Channels interface.
 
     use WWW::PipeViewer;
     my $obj = WWW::PipeViewer->new(%opts);
-    my $videos = $obj->channels_from_categoryID($category_id);
+    my $videos = $obj->uploads($channel_id);
 
 =head1 SUBROUTINES/METHODS
 
@@ -61,49 +61,15 @@ sub popular_videos {
     return $self->_get_results($url);
 }
 
-=head2 channels_from_categoryID($category_id)
-
-Return the YouTube channels associated with the specified category.
-
 =head2 channels_info($channel_id)
 
 Return information for the comma-separated list of the YouTube channel ID(s).
 
-=head1 Channel details
-
-For all functions, C<$channels->{results}{items}> contains:
-
 =cut
 
-{
-    no strict 'refs';
-
-    foreach my $method (
-                        {
-                         key  => 'categoryId',
-                         name => 'channels_from_guide_category',
-                        },
-                        {
-                         key  => 'id',
-                         name => 'channels_info',
-                        },
-                        {
-                         key  => 'forUsername',
-                         name => 'channels_from_username',
-                        },
-      ) {
-        *{__PACKAGE__ . '::' . $method->{name}} = sub {
-            my ($self, $channel_id) = @_;
-            return $self->_get_results($self->_make_channels_url($method->{key} => $channel_id));
-        };
-    }
-
-    foreach my $part (qw(id contentDetails statistics topicDetails)) {
-        *{__PACKAGE__ . '::' . 'channels_' . $part} = sub {
-            my ($self, $id) = @_;
-            return $self->_get_results($self->_make_channels_url(id => $id, part => $part));
-        };
-    }
+sub channels_info {
+    my ($self, $channel_id) = @_;
+    return $self->_get_results($self->_make_channels_url(id => $channel_id));
 }
 
 =head2 channel_id_from_username($username)

--- a/lib/WWW/PipeViewer/PlaylistItems.pm
+++ b/lib/WWW/PipeViewer/PlaylistItems.pm
@@ -45,25 +45,21 @@ sub videos_from_playlist_id {
     $self->_get_results($url);
 }
 
-=head2 favorites($channel_id)
-
 =head2 uploads($channel_id)
 
-Get the favorites / uploads for a given channel ID.
+Get the uploads for a given channel ID.
 
 =cut
 
-=head2 favorites_from_username($username)
-
 =head2 uploads_from_username($username)
 
-Get the favorites / uploads for a given YouTube username.
+Get the uploads for a given YouTube username.
 
 =cut
 
 {
     no strict 'refs';
-    foreach my $name (qw(favorites uploads)) {
+    foreach my $name (qw(uploads)) {
 
         *{__PACKAGE__ . '::' . $name . '_from_username'} = sub {
             my ($self, $username) = @_;

--- a/lib/WWW/PipeViewer/PlaylistItems.pm
+++ b/lib/WWW/PipeViewer/PlaylistItems.pm
@@ -49,9 +49,7 @@ sub videos_from_playlist_id {
 
 =head2 uploads($channel_id)
 
-=head2 likes($channel_id)
-
-Get the favorites, uploads and likes for a given channel ID.
+Get the favorites / uploads for a given channel ID.
 
 =cut
 
@@ -59,15 +57,13 @@ Get the favorites, uploads and likes for a given channel ID.
 
 =head2 uploads_from_username($username)
 
-=head2 likes_from_username($username)
-
-Get the favorites, uploads and likes for a given YouTube username.
+Get the favorites / uploads for a given YouTube username.
 
 =cut
 
 {
     no strict 'refs';
-    foreach my $name (qw(favorites uploads likes)) {
+    foreach my $name (qw(favorites uploads)) {
 
         *{__PACKAGE__ . '::' . $name . '_from_username'} = sub {
             my ($self, $username) = @_;

--- a/lib/WWW/PipeViewer/PlaylistItems.pm
+++ b/lib/WWW/PipeViewer/PlaylistItems.pm
@@ -45,34 +45,6 @@ sub videos_from_playlist_id {
     $self->_get_results($url);
 }
 
-=head2 uploads($channel_id)
-
-Get the uploads for a given channel ID.
-
-=cut
-
-=head2 uploads_from_username($username)
-
-Get the uploads for a given YouTube username.
-
-=cut
-
-{
-    no strict 'refs';
-    foreach my $name (qw(uploads)) {
-
-        *{__PACKAGE__ . '::' . $name . '_from_username'} = sub {
-            my ($self, $username) = @_;
-            $self->videos_from_username($username);
-        };
-
-        *{__PACKAGE__ . '::' . $name} = sub {
-            my ($self, $channel_id) = @_;
-            $self->videos_from_channel_id($channel_id);
-        };
-    }
-}
-
 =head1 AUTHOR
 
 Trizen, C<< <echo dHJpemVuQHByb3Rvbm1haWwuY29tCg== | base64 -d> >>

--- a/lib/WWW/PipeViewer/Playlists.pm
+++ b/lib/WWW/PipeViewer/Playlists.pm
@@ -73,17 +73,6 @@ sub playlists {
     $self->_get_results($url);
 }
 
-=head2 playlists_from_username($username)
-
-Get and return the playlists created for a given username.
-
-=cut
-
-sub playlists_from_username {
-    my ($self, $username) = @_;
-    $self->playlists($username);
-}
-
 =head1 AUTHOR
 
 Trizen, C<< <echo dHJpemVuQHByb3Rvbm1haWwuY29tCg== | base64 -d> >>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -238,8 +238,6 @@ Author: Trizen https://github.com/trizen
       <column type="gchararray"/>
       <!-- column-name channel_name -->
       <column type="gchararray"/>
-      <!-- column-name type -->
-      <column type="gchararray"/>
       <!-- column-name logo -->
       <column type="GdkPixbuf"/>
     </columns>
@@ -2459,7 +2457,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                         <child>
                           <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf14"/>
                           <attributes>
-                            <attribute name="pixbuf">3</attribute>
+                            <attribute name="pixbuf">2</attribute>
                           </attributes>
                         </child>
                       </object>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1354,47 +1354,6 @@ When the specified resolution is not found, the best available resolution is use
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkFrame" id="frame26">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label-xalign">0</property>
-                                    <property name="shadow-type">none</property>
-                                    <child>
-                                      <object class="GtkAlignment" id="alignment5">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="top-padding">4</property>
-                                        <property name="left-padding">12</property>
-                                        <property name="right-padding">12</property>
-                                        <child>
-                                          <object class="GtkEntry" id="entry4">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <signal name="activate" handler="subscriptions_from_text_entry" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="label34">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="xpad">4</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Subscriptions:&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
                                   <object class="GtkFrame" id="frame29">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1354,47 +1354,6 @@ When the specified resolution is not found, the best available resolution is use
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkFrame" id="frame29">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label-xalign">0</property>
-                                    <property name="shadow-type">none</property>
-                                    <child>
-                                      <object class="GtkAlignment" id="alignment27">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="top-padding">4</property>
-                                        <property name="left-padding">12</property>
-                                        <property name="right-padding">12</property>
-                                        <child>
-                                          <object class="GtkEntry" id="entry5">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <signal name="activate" handler="likes_from_text_entry" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="label37">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="xpad">4</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Likes:&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
                                   <object class="GtkFrame" id="frame2">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1353,50 +1353,6 @@ When the specified resolution is not found, the best available resolution is use
                                     <property name="position">4</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkFrame" id="frame28">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label-xalign">0</property>
-                                    <property name="label-yalign">0</property>
-                                    <property name="shadow-type">none</property>
-                                    <child>
-                                      <object class="GtkAlignment" id="alignment26">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="top-padding">4</property>
-                                        <property name="left-padding">12</property>
-                                        <property name="right-padding">12</property>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="comboboxtext7">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">username</item>
-                                              <item translatable="yes">channel ID</item>
-                                            </items>
-                                            <signal name="changed" handler="combobox_channel_type_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="label36">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="xpad">4</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Channel type:&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">5</property>
-                                  </packing>
-                                </child>
                               </object>
                               <packing>
                                 <property name="position">1</property>

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1312,48 +1312,6 @@ When the specified resolution is not found, the best available resolution is use
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkFrame" id="frame24">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label-xalign">0</property>
-                                    <property name="shadow-type">none</property>
-                                    <child>
-                                      <object class="GtkAlignment" id="alignment23">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="top-padding">4</property>
-                                        <property name="left-padding">12</property>
-                                        <property name="right-padding">12</property>
-                                        <child>
-                                          <object class="GtkEntry" id="entry3">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Insert an YouTube username</property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <signal name="activate" handler="favorites_from_text_entry" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="label30">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="xpad">4</property>
-                                        <property name="label" translatable="yes">&lt;b&gt;Favorites:&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
                                   <object class="GtkFrame" id="frame2">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>


### PR DESCRIPTION
- getting a channel's likes/favorites is unsupported, remove the corresponding code and simplify the GUI "Channel" panel.
- remove `WWW::PipeViewer::(playlists|uploads)_from_username` methods: they are just aliases for `videos_from_channel_id`, which already handle both cases (passing a channel ID or a channel's username with no spaces), and rename `videos_from_channel_id` to `uploads`.
- simplify the the CLI and GUI code accordingly (including, again, the GUI "Channel" panel).
- fix listing the videos of a comment author in the CLI

IMHO, we should just remove the GUI "Channel" panel, maybe remove the 2 entries in the users list window too, rational:
- listing a channel playlists / uploads by username is severely limited: it only works when there's no space in the username, and only for Youtube (and not Invidious contrary to what the API's documentation says).
- it's easier IMHO to just do a standard channel search, and use the right context menu, as it handle all cases: searching by username (including with spaces), and searching for a channel by title.
- and the channel ID case, we could just extend the keyword channel regular expression to check for an ID: handle `UC7y4qaRSb5w2O8cCHOsKZDw` by itself instead of only checking for a full URL like `https://www.youtube.com/channel/UC7y4qaRSb5w2O8cCHOsKZDw`.