### PR TITLE
GUI: tweak details window

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -361,10 +361,14 @@ my %objects = (
     'help_window'       => \my $help_window,
     'preferences_window'=> \my $preferences_window,
     'errors_window'     => \my $errors_window,
-    'details_window'    => \my $details_window,
     'aboutdialog1'      => \my $about_window,
     'feeds_window'      => \my $feeds_window,
     'warnings_window'   => \my $warnings_window,
+
+    # Details window.
+    'details_window'   => \my $details_window,
+    'details_flowbox1' => \my $details_flowbox1,
+    'details_flowbox2' => \my $details_flowbox2,
 
     # Others
     'treeview1'              => \my $users_treeview,
@@ -3733,6 +3737,8 @@ sub set_entry_details {
     $gui->get_object('video_title_label')->set_tooltip_markup("<b>$title</b>");
 
     my $text_info;
+    my @details1;
+    my @details2;
 
     if ($type eq 'video') {
 
@@ -3744,60 +3750,68 @@ sub set_entry_details {
             }
         }
 
-        my $likes    = $yv_utils->get_likes($info);
-        my $views    = $yv_utils->get_views($info);
-
-        $text_info = join(
-                          "\n",
-                          map    { sprintf("%s  %s", $_->[0], $_->[1]) }
-                            grep { defined($_->[1]) } (
-                                                       [$symbols{author}      => $yv_utils->get_channel_title($info)],
-                                                       [$symbols{category}    => $yv_utils->get_category_name($info)],
-                                                       [$symbols{thumbs_up}   => $yv_utils->set_thousands($likes)],
-                                                       [$symbols{average}     => $yv_utils->get_rating($info)],
-                                                       [$symbols{play}        => $yv_utils->get_time($info)],
-                                                       [$symbols{views}       => $yv_utils->set_thousands($views)],
-                                                       [$symbols{published}   => $yv_utils->get_publication_date($info)],
-                                                       [$symbols{author_id}   => $yv_utils->get_channel_id($info)],
-                                                      )
-                         );
-
-        $text_info .= "\n";
+        @details1 = (
+            author    => $yv_utils->get_channel_title($info),
+            author_id => $yv_utils->get_channel_id($info),
+        );
+        @details2 = (
+            published => $yv_utils->get_publication_date($info),
+            play      => $yv_utils->get_time($info),
+            thumbs_up => $yv_utils->get_likes($info),
+            views     => $yv_utils->get_views($info),
+            average   => $yv_utils->get_rating($info),
+        );
     }
     elsif ($type eq 'playlist') {
-
-        my $details_format = <<"EOT";
-‎$symbols{author}\t%s
-‎$symbols{video}\t%s videos
-$symbols{author_id}\t%s
-$symbols{play}\t%s
-EOT
-
-        $text_info = sprintf($details_format,
-                             $yv_utils->get_channel_title($info) // 'unknown',
-                             $yv_utils->set_thousands($yv_utils->get_playlist_video_count($info) // 0),
-                             $yv_utils->get_channel_id($info)  // 'unknown',
-                             $yv_utils->get_playlist_id($info) // 'unknown',
-                            );
+        @details1 = (
+            author    => $yv_utils->get_channel_title($info),
+            author_id => $yv_utils->get_channel_id($info),
+            play      => $yv_utils->get_playlist_id($info),
+        );
+        @details2 = (
+            video     => $yv_utils->get_playlist_video_count($info),
+        );
     }
     elsif ($type eq 'channel') {
-
-        my $details_format = <<"EOT";
-‎$symbols{author}\t%s
-‎$symbols{video}\t%s videos
-‎$symbols{subs}\t%s subscribers
-$symbols{author_id}\t%s
-EOT
-
-        $text_info = sprintf($details_format,
-                             $yv_utils->get_channel_title($info) // 'unknown',
-                             $yv_utils->short_human_number($yv_utils->get_video_count($info)      // 0),
-                             $yv_utils->short_human_number($yv_utils->get_subscriber_count($info) // 0),
-                             $yv_utils->get_channel_id($info) // 'unknown',
-                            );
+        @details1 = (
+            author    => $yv_utils->get_channel_title($info),
+            author_id => $yv_utils->get_channel_id($info),
+        );
+        @details2 = (
+            video => $yv_utils->get_playlist_video_count($info),
+            subs  => $yv_utils->get_subscriber_count($info),
+        );
     }
 
-    $gui->get_object('video_details_label')->set_label("<big>" . encode_entities("\n" . $text_info) . "</big>");
+    my %humanize_number_fields = (
+        likes     => 1,
+        subs      => 1,
+        thumbs_up => 1,
+        views     => 1,
+    );
+
+    for my $pair (pairs($details_flowbox1, \@details1, $details_flowbox2, \@details2)) {
+        my ($flowbox, $fields) = @$pair;
+        for my $child ($flowbox->get_children) {
+            $child->destroy;
+        }
+        foreach my $field (pairs(@$fields)) {
+            my ($symbol, $value) = @$field;
+            my $tooltip;
+            $value //= 'N/A';
+            if (looks_like_number($value) && exists $humanize_number_fields{$symbol}) {
+                my $raw_value = $value;
+                $value   = $yv_utils->short_human_number($value);
+                $tooltip = $yv_utils->set_thousands($raw_value) if $value ne $raw_value;
+            }
+            my $label = Gtk3::Label->new("$symbols{$symbol}  $value");
+            $label->set_tooltip_text($tooltip) if $tooltip;
+            $label->set_selectable(1);
+            $label->set_xalign(0.0);
+            $label->show();
+            $flowbox->add($label);
+        }
+    }
 
     # Setting the link button
     my $url        = make_youtube_url($type, $code);

--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -3750,7 +3750,6 @@ sub set_entry_details {
         $text_info = join(
                           "\n",
                           map    { sprintf("%s  %s", $_->[0], $_->[1]) }
-                            grep { $_->[1] !~ /^(0|unknown)\z/i }
                             grep { defined($_->[1]) } (
                                                        [$symbols{author}      => $yv_utils->get_channel_title($info)],
                                                        [$symbols{category}    => $yv_utils->get_category_name($info)],

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -4005,7 +4005,6 @@ sub print_video_info {
           q{ } x $rep => (_bold_color("=>> $title <<=") . "\n\n"),
           (
            map    { sprintf(q{-> } . "%-*s: %s\n", $opt{_colors} ? 18 : 10, _bold_color($_->[0]), $_->[1]) }
-             grep { $_->[1] !~ /^(0|unknown)\z/i }
              grep { defined($_->[1]) } (
                                         ['Channel'    => $yv_utils->get_channel_title($video)],
                                         ['ChannelID'  => $yv_utils->get_channel_id($video)],

--- a/lib/WWW/PipeViewer/Utils.pm
+++ b/lib/WWW/PipeViewer/Utils.pm
@@ -810,11 +810,6 @@ sub get_channel_id {
     $info->{authorId};
 }
 
-sub get_category_id {
-    my ($self, $info) = @_;
-    $info->{genre} // $info->{category} // 'Unknown';
-}
-
 sub get_category_name {
     my ($self, $info) = @_;
 

--- a/lib/WWW/PipeViewer/Utils.pm
+++ b/lib/WWW/PipeViewer/Utils.pm
@@ -798,9 +798,6 @@ sub get_rating {
     if ($likes and $views and $views >= $likes) {
         $rating = sprintf("%.2g%%", log($likes + 1) / log($views + 1) * 100);
     }
-    else {
-        $rating = "N/A";
-    }
 
     return $rating;
 }
@@ -812,7 +809,7 @@ sub get_channel_id {
 
 sub get_category_name {
     my ($self, $info) = @_;
-    $info->{genre} // $info->{category} // 'Unknown';
+    $info->{genre} // $info->{category};
 }
 
 sub get_publication_date {
@@ -1001,7 +998,7 @@ sub get_views_approx {
 
 sub get_likes {
     my ($self, $info) = @_;
-    $info->{likeCount} // 0;
+    $info->{likeCount};
 }
 
 {

--- a/lib/WWW/PipeViewer/Utils.pm
+++ b/lib/WWW/PipeViewer/Utils.pm
@@ -812,25 +812,6 @@ sub get_channel_id {
 
 sub get_category_name {
     my ($self, $info) = @_;
-
-    state $categories = {
-                         1  => 'Film & Animation',
-                         2  => 'Autos & Vehicles',
-                         10 => 'Music',
-                         15 => 'Pets & Animals',
-                         17 => 'Sports',
-                         19 => 'Travel & Events',
-                         20 => 'Gaming',
-                         22 => 'People & Blogs',
-                         23 => 'Comedy',
-                         24 => 'Entertainment',
-                         25 => 'News & Politics',
-                         26 => 'Howto & Style',
-                         27 => 'Education',
-                         28 => 'Science & Technology',
-                         29 => 'Nonprofits & Activism',
-                        };
-
     $info->{genre} // $info->{category} // 'Unknown';
 }
 

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1565,6 +1565,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area3">
             <property name="can-focus">False</property>
@@ -1576,9 +1577,6 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
             <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>
@@ -1905,6 +1903,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">1</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
@@ -2510,6 +2509,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
       <object class="GtkBox" id="dialog-vbox5">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">1</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area5">

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -1582,6 +1582,8 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
     </child>
   </object>
   <object class="GtkDialog" id="details_window">
+    <property name="width-request">800</property>
+    <property name="height-request">600</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Extra details</property>
     <property name="modal">True</property>
@@ -1603,6 +1605,21 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
             <property name="can-focus">False</property>
             <property name="layout-style">end</property>
             <child>
+              <object class="GtkLinkButton" id="linkbutton1">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="halign">start</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="play">
                 <property name="label">gtk-media-play</property>
                 <property name="visible">True</property>
@@ -1614,7 +1631,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -1629,7 +1646,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -1643,7 +1660,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>
@@ -1749,26 +1766,27 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">4</property>
                 <child>
-                  <object class="GtkLabel" id="video_details_label">
+                  <object class="GtkFlowBox" id="details_flowbox1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="use-markup">True</property>
-                    <property name="wrap">True</property>
-                    <property name="selectable">True</property>
-                    <property name="ellipsize">end</property>
-                    <property name="width-chars">35</property>
+                    <property name="max-children-per-line">1</property>
+                    <property name="selection-mode">none</property>
+                    <property name="activate-on-single-click">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSeparator">
+                  <object class="GtkFlowBox" id="details_flowbox2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="selection-mode">none</property>
+                    <property name="activate-on-single-click">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1777,14 +1795,22 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkSeparator">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-end">4</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">4</property>
-                    <property name="margin-right">4</property>
-                    <property name="margin-start">4</property>
                     <property name="margin-end">4</property>
-                    <property name="margin-top">4</property>
                     <property name="margin-bottom">4</property>
                     <property name="label-xalign">0</property>
                     <property name="shadow-type">out</property>
@@ -1829,7 +1855,7 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
@@ -1843,31 +1869,6 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButtonBox" id="hbuttonbox10">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="layout-style">center</property>
-            <child>
-              <object class="GtkLinkButton" id="linkbutton1">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="relief">none</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
           </packing>
         </child>
         <child>


### PR DESCRIPTION
Give more space to the description by making the details panel more compact and moving the link button to the bottom of the button box.

Before:
![before](https://user-images.githubusercontent.com/5104286/192364132-44fe33d9-061f-42f1-9ca1-3eef0adbe5b4.png)

After:
![after](https://user-images.githubusercontent.com/5104286/192364157-52bf0486-9381-4265-ae06-77d79e3f880b.png)

When a number is shortened, the full value is available as a tooltip:
![after_tooltip](https://user-images.githubusercontent.com/5104286/192364288-6a4f8924-b54e-4071-b529-aff0574d1114.png)

Note: the category name is not displayed, as for now it's never available with the method used to get a video details.