### PR TITLE
gui: rework the comments window

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -227,8 +227,12 @@ my %CONFIG = (
     date             => 'anytime',
     region           => undef,
 
-    comments_width => 80,              # wrap comments longer than `n` characters
-    comments_order => 'top',           # valid values: time, relevance
+    comments_order              => 'top',           # valid values: top, new
+    comments_author_color       => undef,
+    comments_date_color         => undef,
+    comments_body_color         => undef,
+    comments_load_more_color    => undef,
+    comments_show_replies_color => undef,
 
     # API
     api_host => "auto",
@@ -364,8 +368,12 @@ my %objects = (
     'preferences_window' => \my $preferences_window,
     'errors_window'      => \my $errors_window,
     'aboutdialog1'       => \my $about_window,
-    'feeds_window'       => \my $feeds_window,
     'warnings_window'    => \my $warnings_window,
+
+    # Comments window.
+    'feeds_window'     => \my $feeds_window,
+    'feeds_title'      => \my $feeds_title,
+    'comments_view'    => \my $comments_view,
 
     # Details window.
     'details_window'   => \my $details_window,
@@ -378,11 +386,9 @@ my %objects = (
     'treeview1'              => \my $users_treeview,
     'treeview2'              => \my $treeview,
     'treeview3'              => \my $cat_treeview,
-    'feeds_treeview'         => \my $feeds_treeview,
     'liststore1'             => \my $liststore,
     'liststore2'             => \my $users_liststore,
     'liststore4'             => \my $cats_liststore,
-    'liststore11'            => \my $feeds_liststore,
     'textview3'              => \my $config_view,
     'warnings_textview'      => \my $warnings_textview,
     'errors_textview'        => \my $errors_textview,
@@ -404,7 +410,6 @@ my %objects = (
     'dash_checkbutton'       => \my $dash_checkbutton,
     'audio_only_checkbutton' => \my $audio_only_checkbutton,
     'hbox2'                  => \my $hbox2,
-    'feeds_title'            => \my $feeds_title,
     'main-menu-history-menu' => \my $history_menu,
     'features_flowbox'       => \my $features_flowbox,
     'progressbar'            => \my $progressbar,
@@ -1659,7 +1664,6 @@ my $search_request;
 my $results_thumbs_request;
 my $details_request;
 my $details_thumbs_request;
-my $comments_request;
 
 my $progress_timer;
 
@@ -1855,67 +1859,6 @@ sub show_details_window {
     $details_request = $details_thumbs_request = undef;
     set_entry_details($code, $iter);
     $details_window->show;
-
-    return 1;
-}
-
-my $comments_spinner;
-
-sub start_comments_spinner {
-    die if $comments_spinner;
-    my $iter = $feeds_liststore->append;
-    my $timer = Glib::Timeout->add(
-        80,
-        sub {
-            state $pulse = 1;
-            $feeds_liststore->set($iter, [6], [++$pulse]);
-            return 1;
-        },
-    );
-    $feeds_liststore->set($iter, [5, 7], [$timer, 0]);
-    $comments_spinner = $iter;
-    return;
-}
-
-sub stop_comments_spinner {
-    return unless $comments_spinner;
-    Glib::Source->remove($feeds_liststore->get($comments_spinner, 5));
-    $feeds_liststore->remove($comments_spinner);
-    $comments_spinner = undef;
-    return;
-}
-
-sub set_comments {
-    my $videoID = get_selected_entry_code(type => 'video') // return;
-    stop_comments_spinner();
-    $feeds_liststore->clear;
-    start_comments_spinner();
-    $worker->abort_requests($comments_request);
-    $comments_request = $worker->send_request(
-        sub {
-            my $results = $_[0];
-            stop_comments_spinner();
-            $comments_request = undef;
-            display_comments($results);
-        },
-        'comments_from_video_id',
-        [$videoID],
-        priority => REQUEST_PRIORITY_COMMENTS,
-    );
-}
-
-# Comments window
-sub show_comments_window {
-    my ($videoID, $iter) = get_selected_entry_code(type => 'video');
-    $videoID // return;
-
-    my $info = $liststore->get($iter, 0);
-    my ($video_title) = $info =~ m{^.*?(<big><b>.*?</b></big>)}s;
-
-    $feeds_title->set_markup("<big>$video_title</big>");
-    $feeds_title->set_tooltip_markup("$video_title");
-    $feeds_window->show;
-    set_comments();
 
     return 1;
 }
@@ -3478,47 +3421,6 @@ sub download_video {
     return 1;
 }
 
-sub comments_row_activated {
-
-    my $iter = $feeds_treeview->get_selection->get_selected() or return;
-
-    # Spinner.
-    return if $feeds_liststore->get($iter, 5);
-
-    # Next page.
-    my $url = $feeds_liststore->get($iter, 1);
-    if ($url and $url =~ m{^https?://}) {
-
-        my $token = $feeds_liststore->get($iter, 2);
-        $feeds_liststore->remove($iter);
-
-        start_comments_spinner();
-        $worker->abort_requests($comments_request);
-        $comments_request = $worker->send_request(
-            sub {
-                my $results = $_[0];
-                stop_comments_spinner();
-                $comments_request = undef;
-                die "This is the last page of comments.\n"
-                  unless ($yv_utils->has_entries($results));
-                display_comments($results);
-            },
-            'next_page_with_token',
-            [$url, $token],
-            priority => REQUEST_PRIORITY_COMMENTS
-        );
-
-        return 1;
-    }
-
-    my ($video_id, $comment_id) = $feeds_liststore->get($iter, 3, 4);
-    my $comment_url = sprintf "https://www.youtube.com/watch?v=%s&lc=%s", $video_id, $comment_id;
-
-    open_external_url($comment_url);
-
-    return 1;
-}
-
 sub get_channel_id_for_selected_video {
     my $selection = $treeview->get_selection() // return;
     my $iter      = $selection->get_selected() // return;
@@ -3531,119 +3433,317 @@ sub show_related_videos {
     return;
 }
 
-sub wrap_text {
-    my (%args) = @_;
+# -------------  Comments window ------------- #
 
-    require Text::Wrap;
-    local $Text::Wrap::columns = $CONFIG{comments_width};
+my $REPLIES_INDICATOR_EXPAND   = '▾';
+my $REPLIES_INDICATOR_COLLAPSE = '▴';
 
-    my $text = "@{$args{text}}";
-    $text =~ tr{\r}{}d;
+# Note: the behavior when multiple tags with conflicting
+# attributes are applied to the same range is undefined.
+my @COMMENTS_TAGS = (
+                     author => {
+                                foreground         => $CONFIG{comments_author_color},
+                                pixels_above_lines => 8,
+                                pixels_below_lines => 8,
+                                scale              => 1.2,
+                                weight             => 700,
+                               },
+                     date => {
+                              foreground => $CONFIG{comments_date_color},
+                              style      => 'italic',
+                             },
+                     body => {
+                              foreground   => $CONFIG{comments_body_color},
+                              right_margin => 16,
+                             },
+                     hotspot      => {},
+                     show_replies => {
+                                      foreground         => $CONFIG{comments_show_replies_color},
+                                      pixels_above_lines => 8,
+                                      weight             => 700,
+                                     },
+                     replies   => {},
+                     load_more => {
+                                   foreground         => $CONFIG{comments_load_more_color},
+                                   pixels_above_lines => 8,
+                                   weight             => 700,
+                                  },
+                     hidden => {
+                                invisible => 1,
+                               },
+                     indent_0 => {
+                                  left_margin => 8,
+                                 },
+                     indent_1 => {
+                                  left_margin => 16,
+                                 },
+                     indent_2 => {
+                                  left_margin => 32,
+                                 },
+                     indent_3 => {
+                                  left_margin => 40,
+                                 },
+                    );
 
-    eval { Text::Wrap::wrap($args{i_tab}, $args{s_tab}, $text) } // $text;
+my $comments_buffer;
+my %comments_requests;
+
+sub comments_buffer_delete_at_mark {
+    my ($mark, $movement, @movement_args) = @_;
+    my $start_iter = $comments_buffer->get_iter_at_mark($mark);
+    my $end_iter = $start_iter->copy();
+    $end_iter->can($movement)->($end_iter, @movement_args);
+    $comments_buffer->delete($start_iter, $end_iter);
+    return;
+}
+
+sub comments_spinner_insert {
+    my ($mark, $indent) = @_;
+    my $iter        = $comments_buffer->get_iter_at_mark($mark);
+    my $indent_tag  = $comments_buffer->{"indent_${indent}_tag"};
+    my $left_margin = $indent_tag->get_property('left_margin');
+    my $spinner     = Gtk3::Spinner->new();
+    $spinner->{mark} = $mark;
+    $spinner->set_margin_left($left_margin);
+    $spinner->set_margin_bottom(4);
+    $spinner->set_margin_top(8);
+    $spinner->show();
+    $comments_view->add_child_at_anchor($spinner, $comments_buffer->create_child_anchor($iter));
+    # For some reason, starting the spinner directly does not always work…
+    Glib::Idle->add(sub { $spinner->start() });
+    return $spinner;
+}
+
+sub comments_spinner_delete {
+    my ($spinner) = @_;
+    comments_buffer_delete_at_mark($spinner->{mark}, 'forward_char');
+    return;
+}
+
+sub comments_buffer_reset {
+    # Swap buffer with a new pristine one.
+    $comments_buffer = Gtk3::TextBuffer->new();
+    $comments_view->set_buffer($comments_buffer);
+    # And create all the necessary tags.
+    for my $tag_spec (pairs(@COMMENTS_TAGS)) {
+        my ($name, $attrs) = @$tag_spec;
+        $comments_buffer->{"${name}_tag"} = $comments_buffer->create_tag($name, %$attrs);
+    }
+}
+
+sub comments_load {
+    my ($request_method, $request_params, %args) = @_;
+    $args{mark}   //= $comments_buffer->create_mark(undef, $comments_buffer->get_end_iter(), 1);
+    $args{indent} //= 0;
+    my $spinner = comments_spinner_insert($args{mark}, $args{indent});
+    $comments_requests{
+        $worker->send_request(
+            sub {
+                my ($results, $request) = @_;
+                my $error = $args{error};
+                comments_spinner_delete($spinner);
+                delete $comments_requests{$request->{id}};
+                if ($yv_utils->has_entries($results)) {
+                    display_comments($results, $args{mark}, $args{indent});
+                    $error = undef;
+                }
+                $comments_buffer->delete_mark($args{mark});
+                die "$error\n" if $error;
+                return;
+            },
+            $request_method,
+            $request_params,
+            priority => REQUEST_PRIORITY_COMMENTS,
+        )
+    } = 1;
+}
+
+sub comments_vscroll_value_changed_cb {
+    comments_check_for_hotspot_at_pos();
+    return 0;
+}
+
+sub comments_view_button_press_event_cb {
+    my ($widget, $event) = @_;
+    return 0 if $event->button != 1;
+    my ($x, $y) = $widget->window_to_buffer_coords('text', $event->x, $event->y);
+    my $iter = $widget->get_iter_at_location($x, $y);
+    return 0 unless $iter->has_tag($comments_buffer->{hotspot_tag});
+    $iter->backward_to_tag_toggle($comments_buffer->{hotspot_tag});
+    for my $mark (@{$iter->get_marks() // []}) {
+        my $code = $mark->{code} // next;
+        $code->($mark);
+    }
+    return 1;
+}
+
+sub comments_check_for_hotspot_at_pos {
+    my ($x, $y) = @_;
+    state $pointer_cursor = Gtk3::Gdk::Cursor->new_from_name($comments_view->get_display(), 'pointer');
+    state $text_cursor    = Gtk3::Gdk::Cursor->new_from_name($comments_view->get_display(), 'text');
+    unless (defined $x and defined $y) {
+        ($x, $y) = $comments_view->get_pointer();
+        my $size = $comments_view->get_allocation();
+        return if $x < 0 or $y < 0 or $x >= $size->{width} or $y >= $size->{height};
+    }
+    ($x, $y) = $comments_view->window_to_buffer_coords('text', $x, $y);
+    my $iter   = $comments_view->get_iter_at_location($x, $y);
+    my $cursor = $iter->has_tag($comments_buffer->{hotspot_tag}) ? $pointer_cursor : $text_cursor;
+    $comments_view->get_window('text')->set_cursor($cursor);
+    return;
+}
+
+sub comments_view_motion_notify_event_cb {
+    my ($widget, $event) = @_;
+    comments_check_for_hotspot_at_pos($event->x, $event->y);
+    return 0;
+}
+
+sub comments_view_focus_in_event_cb {
+    comments_check_for_hotspot_at_pos();
+    return 0;
+}
+
+sub comments_replies_toggle {
+    my ($mark) = @_;
+    $mark->{expanded} = not $mark->{expanded};
+    # Update the indicator.
+    comments_buffer_delete_at_mark($mark, 'forward_char');
+    my $iter      = $comments_buffer->get_iter_at_mark($mark);
+    my $indicator = $mark->{expanded} ? $REPLIES_INDICATOR_COLLAPSE : $REPLIES_INDICATOR_EXPAND;
+    $comments_buffer->insert_with_tags($iter, $indicator, @{$iter->get_toggled_tags(1)});
+    # Toggle the replies' visibility.
+    $iter->forward_to_tag_toggle($comments_buffer->{replies_tag});
+    (my $end_iter = $iter->copy())->forward_to_tag_toggle($comments_buffer->{replies_tag});
+    $comments_buffer->can(($mark->{expanded} ? 'remove' : 'apply') . '_tag_by_name')
+      ->($comments_buffer, 'hidden', $iter, $end_iter);
+    # Ditto with the spinner if present.
+    $end_iter->backward_line();
+    my $spinner = ($end_iter->get_child_anchor() // return)->get_widgets()->[0];
+    $spinner->can($mark->{expanded} ? 'show' : 'hide')->($spinner);
+    return;
 }
 
 sub display_comments {
-    my ($results) = @_;
+    my ($results, $start_mark, $indent) = @_;
 
     return 1 if ref($results) ne 'HASH';
 
     my $url          = $results->{url};
     my $video_id     = $results->{results}{videoId};
-    my $comments     = $results->{results}{comments} // [];
     my $continuation = $results->{results}{continuation};
+    my $comments     = $results->{results}{comments} // [];
+
+    my $iter   = $comments_buffer->get_iter_at_mark($start_mark);
+    my $insert = sub {
+        my ($text, @tags) = @_;
+        $comments_buffer->insert_with_tags_by_name($iter, $text, "indent_$indent", @tags);
+    };
 
     foreach my $comment (@{$comments}) {
 
-        my $comment_id  = $yv_utils->get_comment_id($comment);
-        my $comment_age = $yv_utils->get_publication_age($comment);
+        $insert->("\n") unless $iter->starts_line();
 
-        if ($comment_age) {
-            if ($comment_age !~ / ago\b/) {
-                $comment_age = "$comment_age ago";
+        my $comment_id = $yv_utils->get_comment_id($comment);
+
+        # Author.
+        $insert->($yv_utils->get_author($comment), qw(author));
+        $insert->(q{  });
+
+        # Date.
+        {
+            my $comment_url = sprintf "https://www.youtube.com/watch?v=%s&lc=%s", $video_id, $comment_id;
+            my $comment_age = $yv_utils->get_publication_age($comment);
+            if ($comment_age) {
+                $comment_age = "$comment_age ago" if $comment_age !~ / ago\b/;
             }
-        }
-        else {
-            $comment_age = $yv_utils->get_publication_date($comment) // 'unknown';
-        }
-
-        my $comment_text = reflow_text(
-                                      sprintf(
-                                              "<big><b>%s</b> (%s) commented:</big>\n%s",
-                                              encode_entities($yv_utils->get_author($comment)),
-                                              $comment_age,
-                                              encode_entities(
-                                                  wrap_text(
-                                                      i_tab => "\t",
-                                                      s_tab => "\t",
-                                                      text => [$yv_utils->get_comment_content($comment) // 'Empty comment...'],
-                                                  )
-                                              ),
-                                             )
-                                      );
-
-        if (not $comment->{_hidden}) {
-            $feeds_liststore->insert_with_values(
-                                                 -1,
-                                                 0 => $comment_text,
-                                                 3 => $video_id,
-                                                 4 => $comment_id,
-                                                 7 => 1,
-                                                );
-        }
-
-        if (exists($comment->{replies}) and ref($comment->{replies}) eq 'ARRAY') {
-
-            foreach my $reply (@{$comment->{replies}}) {
-
-                my $reply_id  = $yv_utils->get_comment_id($reply);
-                my $reply_age = $yv_utils->get_publication_age($reply);
-
-                if ($reply_age) {
-                    $reply_age = "$reply_age ago";
-                }
-                else {
-                    $reply_age = $yv_utils->get_publication_date($reply) // 'unknown';
-                }
-
-                my $reply_text = reflow_text(
-                                          sprintf(
-                                                  "\t<big><b>%s</b> (%s) replied:</big>\n%s",
-                                                  encode_entities($yv_utils->get_author($reply)),
-                                                  $reply_age,
-                                                  encode_entities(
-                                                      wrap_text(
-                                                          i_tab => "\t\t",
-                                                          s_tab => "\t\t",
-                                                          text => [$yv_utils->get_comment_content($reply) // 'Empty reply...'],
-                                                      )
-                                                  ),
-                                                 )
-                                            );
-
-                $feeds_liststore->insert_with_values(
-                                                     -1,
-                                                     0 => $reply_text,
-                                                     3 => $video_id,
-                                                     4 => $reply_id,
-                                                     7 => 1,
-                                                    );
+            else {
+                $comment_age = $yv_utils->get_publication_date($comment) // 'unknown';
             }
+            my $mark = $comments_buffer->create_mark(undef, $iter, 1);
+            $mark->{code} = sub { open_external_url($comment_url) };
+            $insert->($comment_age, qw(date hotspot));
+            $insert->("\n");
         }
+
+
+        # Body.
+        $indent += 1;
+        $insert->($yv_utils->get_comment_content($comment) // q{}, qw(body));
+        $indent -= 1;
+
+        # Replies.
+        next unless exists $comment->{replies} and ref($comment->{replies}) eq 'HASH';
+        $indent += 1;
+        $insert->("\n");
+        my $replies_continuation = $comment->{replies}{continuation};
+        my $replies_count        = $comment->{replies}{replyCount};
+        my $replies_header       = sprintf '%s  %s %s',
+          $REPLIES_INDICATOR_EXPAND, $replies_count,
+          $replies_count > 1 ? 'REPLIES' : 'REPLY';
+        my $mark1 = $comments_buffer->create_mark(undef, $iter, 1);
+        $insert->($replies_header, qw(hotspot show_replies));
+        my $replies_indent = $indent += 1;
+        $insert->("\n", qw(hidden replies));
+        my $mark2 = $comments_buffer->create_mark(undef, $iter, 1);
+        $mark1->{expanded} = 0;
+        $mark1->{code} = sub {
+            comments_replies_toggle($mark1);
+            $mark1->{code} = \&comments_replies_toggle;
+            $comments_buffer->insert_with_tags_by_name($comments_buffer->get_iter_at_mark($mark2), "\n", qw(replies));
+            comments_load(
+                          'next_page_with_token',
+                          [$url, $replies_continuation],
+                          error  => 'Failed to fetch replies.',
+                          indent => $replies_indent,
+                          mark   => $mark2,
+                         );
+        };
+        $indent -= 2;
     }
 
+    # "Load more".
     if (defined $continuation) {
-        $feeds_liststore->insert_with_values(
-                                             -1,
-                                             0 => "<big><b>LOAD MORE</b></big>",
-                                             1 => $url,
-                                             2 => $continuation,
-                                             7 => 1,
-                                            );
+        $insert->("\n") unless $iter->starts_line();
+        my $mark1 = $comments_buffer->create_mark(undef, $iter, 1);
+        $insert->('LOAD MORE', qw(hotspot load_more));
+        $mark1->{code} = sub {
+            comments_buffer_delete_at_mark($mark1, 'forward_to_line_end');
+            comments_load(
+                          'next_page_with_token', [$url, $continuation],
+                          error  => 'Failed to fetch more comments.',
+                          indent => $indent,
+                          mark   => $mark1,
+                         );
+        };
     }
+
+    Glib::Idle->add(\&comments_check_for_hotspot_at_pos);
 
     return 1;
 }
+
+sub set_comments {
+    my $videoID = get_selected_entry_code(type => 'video') // return;
+    $worker->abort_requests(keys %comments_requests);
+    %comments_requests = ();
+    comments_buffer_reset();
+    comments_load('comments_from_video_id', [$videoID]);
+}
+
+sub show_comments_window {
+    my ($videoID, $iter) = get_selected_entry_code(type => 'video');
+    $videoID // return;
+    my $info = $liststore->get($iter, 0);
+    my ($video_title) = $info =~ m{^.*?(<big><b>.*?</b></big>)}s;
+    $feeds_title->set_markup("<big>$video_title</big>");
+    $feeds_title->set_tooltip_markup("$video_title");
+    $feeds_window->show;
+    set_comments();
+    return 1;
+}
+
+# -------------------------------------------- #
 
 sub save_session {
     $CONFIG{remember_session} || return;

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -22,7 +22,7 @@ Author: Trizen https://github.com/trizen
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk+" version="3.18"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name GTK Pipe Viewer -->
   <!-- interface-description Search and play YouTube videos. -->
@@ -47,6 +47,12 @@ Author: Trizen https://github.com/trizen
     <property name="value">1</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="comments_vscroll">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <signal name="value-changed" handler="comments_vscroll_value_changed_cb" swapped="no"/>
   </object>
   <object class="GtkImage" id="download_icon3">
     <property name="visible">True</property>
@@ -153,26 +159,6 @@ Author: Trizen https://github.com/trizen
       <column type="guint"/>
       <!-- column-name pic_height -->
       <column type="guint"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="liststore11">
-    <columns>
-      <!-- column-name comment -->
-      <column type="gchararray"/>
-      <!-- column-name url -->
-      <column type="gchararray"/>
-      <!-- column-name next_page_token -->
-      <column type="gchararray"/>
-      <!-- column-name video_id -->
-      <column type="gchararray"/>
-      <!-- column-name comment_id -->
-      <column type="gchararray"/>
-      <!-- column-name spinner_timer -->
-      <column type="guint"/>
-      <!-- column-name spinner_pulse -->
-      <column type="guint"/>
-      <!-- column-name show_comments -->
-      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkListStore" id="liststore2">
@@ -1929,38 +1915,20 @@ and others... https://github.com/trizen/pipe-viewer/graphs/contributors</propert
           <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
+            <property name="vadjustment">comments_vscroll</property>
             <property name="shadow-type">in</property>
             <child>
-              <object class="GtkTreeView" id="feeds_treeview">
+              <object class="GtkTextView" id="comments_view">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="model">liststore11</property>
-                <property name="search-column">0</property>
-                <signal name="row-activated" handler="comments_row_activated" swapped="no"/>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn" id="treeviewcolumn7">
-                    <property name="title" translatable="yes">Comments</property>
-                    <property name="clickable">True</property>
-                    <child>
-                      <object class="GtkCellRendererSpinner"/>
-                      <attributes>
-                        <attribute name="visible">5</attribute>
-                        <attribute name="active">5</attribute>
-                        <attribute name="pulse">6</attribute>
-                      </attributes>
-                    </child>
-                    <child>
-                      <object class="GtkCellRendererText" id="cellrenderertext6"/>
-                      <attributes>
-                        <attribute name="visible">7</attribute>
-                        <attribute name="markup">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
+                <property name="editable">False</property>
+                <property name="wrap-mode">word</property>
+                <property name="justification">fill</property>
+                <property name="bottom-margin">8</property>
+                <property name="cursor-visible">False</property>
+                <signal name="button-press-event" handler="comments_view_button_press_event_cb" swapped="no"/>
+                <signal name="focus-in-event" handler="comments_view_focus_in_event_cb" swapped="no"/>
+                <signal name="motion-notify-event" handler="comments_view_motion_notify_event_cb" swapped="no"/>
               </object>
             </child>
           </object>


### PR DESCRIPTION
Switch to a text view for displaying the comments. This has several advantages:

- the comments are automatically re-wrapped when the window is resized
- easier and better formatting (colors, indentation, …)
- allow text selection and copying

Additionally, fix support for replies.

Demo:
![demo](https://user-images.githubusercontent.com/5104286/193482927-4cd15f63-aade-435b-9611-e01af38c87b7.gif)

TODO:

- [x] the indentation is not always correctly applied, no idea why…
