### PR TITLE
gui: fix results focus handling

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -1777,10 +1777,9 @@ sub gtk_widget_hide {
 sub gtk_treeview_button_press {
     my ($widget, $event) = @_;
     return 0 if $event->button != 3;
-    my $selection = $widget->get_selection;
-    my $path      = ($widget->get_path_at_pos($event->x, $event->y))[0] // return 0;
-    $selection->select_path($path);
-    my $iter = $selection->get_selected()           // return 0;
+    my $path = ($widget->get_path_at_pos($event->x, $event->y))[0] // return 0;
+    $widget->set_cursor($path, undef, 0);
+    my $iter = $widget->get_model()->get_iter($path);
     my $menu = $widget->{'get-popup-menu'}->($iter) // return 0;
     $menu->popup(undef, undef, undef, undef, $event->button, $event->time);
     return 1;


### PR DESCRIPTION
Ensure the result is selected **and** focused when right clicking to bring up the popup menu.

Close #126.