### PR TITLE
gui: improve handling of text entries

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -195,7 +195,6 @@ my %CONFIG = (
     video_player_selected => undef,    # autodetect it later
 
     # GUI options
-    clear_text_entries_on_click => 0,
     show_thumbs                 => 1,
     thumbnail_size              => '224x126',
     clear_search_list           => 1,
@@ -488,6 +487,12 @@ $mainw->set_title("$appname $version");
 $mainw->set_icon($app_icon_pixbuf);
 $about_window->set_program_name("$appname $version");
 $about_window->set_logo($app_icon_pixbuf);
+
+# Tweak search entries: allow clicking the search primary
+# icon to activate, and disable said icon for other entries.
+$search_entry->set_icon_sensitive('primary', 1);
+$search_entry->set_icon_activatable('primary', 1);
+$from_author_entry->set_icon_from_pixbuf('primary');
 
 our $CONFIG;
 require $config_file;    # Load the configuration file
@@ -1762,6 +1767,12 @@ sub fetch_thumbnails {
 
 # ---------------- Generic GTK signal handlers ---------------- #
 
+sub gtk_widget_grab_focus {
+    my $widget = $_[-1] // $_[0];
+    $widget->grab_focus;
+    return 1;
+}
+
 sub gtk_widget_show {
     my $widget = $_[-1] // $_[0];
     $widget->show;
@@ -2372,6 +2383,17 @@ sub search {
                        );
 
     return 1;
+}
+
+sub search_or_focus {
+    my ($entry, $position) = @_;
+    if ($position eq 'primary') {
+        search();
+    }
+    elsif ($position eq 'secondary') {
+        $entry->grab_focus();
+    }
+    return 0;
 }
 
 sub encode_entities {
@@ -3260,16 +3282,6 @@ sub list_local_playlist {
 
     my $results = videos_from_data_file($playlist_file, reverse => $reverse_playlist);
     display_results($results);
-}
-
-sub clear_text {
-    my ($entry) = @_;
-
-    if ($entry->get_text() =~ /\.\.\.\z/ or $CONFIG{clear_text_entries_on_click}) {
-        $entry->set_text('');
-    }
-
-    return 0;
 }
 
 sub run_cli_pipe_viewer {

--- a/share/gtk-pipe-viewer.glade
+++ b/share/gtk-pipe-viewer.glade
@@ -422,23 +422,19 @@ Author: Trizen https://github.com/trizen
             <property name="can-focus">False</property>
             <property name="border-width">4</property>
             <child>
-              <object class="GtkEntry" id="search_entry">
+              <object class="GtkSearchEntry" id="search_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="buffer">entrybuffer1</property>
-                <property name="invisible-char">•</property>
                 <property name="activates-default">True</property>
-                <property name="text" translatable="yes">Search for YouTube videos...</property>
                 <property name="caps-lock-warning">False</property>
-                <property name="primary-icon-stock">gtk-find</property>
-                <property name="secondary-icon-activatable">False</property>
                 <signal name="activate" handler="search" swapped="no"/>
-                <signal name="button-press-event" handler="clear_text" swapped="no"/>
-                <signal name="icon-release" handler="search" swapped="no"/>
+                <signal name="icon-press" handler="search_or_focus" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="padding">4</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -466,7 +462,7 @@ Author: Trizen https://github.com/trizen
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="padding">14</property>
+                <property name="padding">4</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -810,18 +806,16 @@ Author: Trizen https://github.com/trizen
                                                 <property name="left-padding">12</property>
                                                 <property name="right-padding">12</property>
                                                 <child>
-                                                  <object class="GtkEntry" id="from_author_entry">
+                                                  <object class="GtkSearchEntry" id="from_author_entry">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">True</property>
                                                     <property name="tooltip-text" translatable="yes">Search in videos uploaded by a specific author.
 Unless the author name is valid, this field is ignored.</property>
                                                     <property name="invisible-char">•</property>
-                                                    <property name="text" translatable="yes">Insert a valid author name...</property>
                                                     <property name="caps-lock-warning">False</property>
-                                                    <property name="primary-icon-activatable">False</property>
-                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="placeholder-text" translatable="yes">Insert a username…</property>
                                                     <signal name="activate" handler="search" swapped="no"/>
-                                                    <signal name="button-press-event" handler="clear_text" swapped="no"/>
+                                                    <signal name="icon-press" handler="gtk_widget_grab_focus" swapped="no"/>
                                                   </object>
                                                 </child>
                                               </object>


### PR DESCRIPTION
- use placeholder text when applicable
- use a secondary "clear" icon for clearing and focusing
- get rid of the `clear_text_entries_on_click` setting