### PR TITLE
Slow buffering on mpv

### DIFF
--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -177,7 +177,7 @@ my %CONFIG = (
                               srt     => q{--sub-file=*SUB*},
                               audio   => q{--audio-file=*AUDIO*},
                               fs      => q{--fullscreen},
-                              arg     => q{--really-quiet --force-media-title=*TITLE* --no-ytdl *URL*},
+                              arg     => q{--really-quiet --force-media-title=*TITLE* *URL*},
                               novideo => q{--no-video},
                              },
                      },

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -177,7 +177,7 @@ my %CONFIG = (
                               srt     => q{--sub-file=*SUB*},
                               audio   => q{--audio-file=*AUDIO*},
                               fs      => q{--fullscreen},
-                              arg     => q{--really-quiet --force-media-title=*TITLE* --no-ytdl *VIDEO*},
+                              arg     => q{--really-quiet --force-media-title=*TITLE* --no-ytdl *URL*},
                               novideo => q{--no-video},
                              },
                      },


### PR DESCRIPTION
The default config uses --no-ytdl and \*VIDEO\* for the args of mpv but this causes extremely slow buffering on slow internet connections and also prevents mpv from showing video chapters.
Would like to know if there is a reason these are used rather than using \*URL\*.