### PR TITLE
More strictly and properly parse start time

### DIFF
--- a/lib/WWW/PipeViewer/Utils.pm
+++ b/lib/WWW/PipeViewer/Utils.pm
@@ -272,15 +272,17 @@ sub get_start_time_from_url {
     my $t = $+{t};
 
     if ($t =~ m{
+        ^
         (?:(?<hour>\d+)h)?
         (?:(?<minute>\d+)m)?
-        (?<second>\d+)s
+        (?:(?<second>\d+)s)?
+        $
     }x) {
         my $hour = int($+{hour} // 0);
         my $minute = int($+{minute} // 0);
-        my $second = int($+{second});
+        my $second = int($+{second} // 0);
         return $hour * 60 * 60 + $minute * 60 + $second;
-    } elsif ($t =~ m/\d+/) {
+    } elsif ($t =~ /^\d+$/) {
         return int($t);
     }
 


### PR DESCRIPTION
The time "6m" is not parsed, since it doesn't have a second component. Therefore, we also let the second component be optional so that times only containing an hour and/or minute component will parse. Example: https://www.youtube.com/watch?v=ZKgPxUPOBqc&t=6m

Additionally, ensure that the entire string matches the regexes, since https://www.youtube.com/watch?v=ZKgPxUPOBqc&t=42lol technically passes otherwise.