### PR TITLE
fix set_thousands regex when separator is .

### DIFF
--- a/lib/WWW/PipeViewer/Utils.pm
+++ b/lib/WWW/PipeViewer/Utils.pm
@@ -525,7 +525,7 @@ sub set_thousands {
     $formatted = reverse $formatted;
     
     # Remove any leading separator that might have been added
-    $formatted =~ s/^$thousands_sep//;
+    $formatted =~ s/^\Q$thousands_sep\E//;
     
     return $formatted;
 }


### PR DESCRIPTION
oupsy

if the locale thousands separator is '.', the regex interprets it as any character, and just crops the first character.

This makes the separator a literal character. So only it get's cropped.