### PR TITLE
feat: add --cookies-from-browser support

### DIFF
--- a/bin/gtk-pipe-viewer
+++ b/bin/gtk-pipe-viewer
@@ -259,7 +259,8 @@ my %CONFIG = (
     max_retries => 3,
     retry_delay => 1,
     user_agent  => undef,
-    cookie_file => undef,
+    cookie_file          => undef,
+    cookies_from_browser => undef,
     prefer_fork => (($^O eq 'linux') ? 0 : 1),
     debug       => 0,
     fullscreen  => 0,
@@ -1082,7 +1083,7 @@ sub apply_configuration {
     foreach my $option_name (
                              qw(
                              api_host cache_dir comments_order
-                             cookie_file debug env_proxy force_fallback http_proxy prefer_av1
+                             cookie_file cookies_from_browser debug env_proxy force_fallback http_proxy prefer_av1
                              prefer_invidious prefer_mp4 region timeout user_agent ytdl ytdl_cmd
                              ytdlp_comments ytdlp_max_comments ytdlp_max_replies
                              bypass_age_gate_native bypass_age_gate_with_proxy

--- a/bin/pipe-viewer
+++ b/bin/pipe-viewer
@@ -249,8 +249,9 @@ my %CONFIG = (
     # Misc options
     autoplay_mode      => 0,
     http_proxy         => undef,
-    cookie_file        => undef,
-    user_agent         => undef,
+    cookie_file          => undef,
+    cookies_from_browser => undef,
+    user_agent           => undef,
     timeout            => undef,
     max_retries        => 3,
     retry_delay        => 1,
@@ -765,6 +766,7 @@ my $yv_obj = WWW::PipeViewer->new(
                                   cache_dir               => $opt{cache_dir},
                                   env_proxy               => $opt{env_proxy},
                                   cookie_file             => $opt{cookie_file},
+                                  cookies_from_browser    => $opt{cookies_from_browser},
                                   http_proxy              => $opt{http_proxy},
                                   user_agent              => $opt{user_agent},
                                   timeout                 => $opt{timeout},
@@ -978,6 +980,7 @@ usage: $execname [options] ([url] | [keywords])
    --skip-youtube-extraction! : Skip video/audio URL extraction, pass YouTube URL directly to player
    --dislikes-api!      : Enable dislikes from https://returnyoutubedislike.com
    --cookies=s          : file to read cookies from and dump cookie
+   --cookies-from-browser=s : extract cookies from a browser (chromium, firefox, chrome, brave, edge, opera, vivaldi)
    --user-agent=s       : specify a custom user agent
    --proxy=s            : set HTTP(S)/SOCKS proxy: 'proto://domain.tld:port/'
                           If authentication is required,
@@ -1254,7 +1257,7 @@ sub apply_configuration {
                              channelId region debug
                              http_proxy page comments_order
                              user_agent force_fallback
-                             cookie_file timeout ytdl ytdl_cmd
+                             cookie_file cookies_from_browser timeout ytdl ytdl_cmd
                              prefer_mp4 prefer_av1 prefer_invidious
                              ytdlp_comments ytdlp_max_comments
                              ytdlp_max_replies
@@ -1660,6 +1663,7 @@ sub parse_arguments {
         'popular-shorts|pshorts=s'      => \$opt{popular_shorts},
 
         'cookie-file|cookies=s'          => \$opt{cookie_file},
+        'cookies-from-browser=s'         => \$opt{cookies_from_browser},
         'user-agent|agent=s'             => \$opt{user_agent},
         'http-proxy|https-proxy|proxy=s' => \$opt{http_proxy},
 
@@ -4953,6 +4957,28 @@ The file must be a C<# Netscape HTTP Cookie File>. Same format as C<youtube-dl> 
 See also:
 
     https://github.com/ytdl-org/youtube-dl#how-do-i-pass-cookies-to-youtube-dl
+
+=head2 cookies_from_browser
+
+Automatically extract cookies from an installed browser using C<yt-dlp>.
+
+Supported values: C<chromium>, C<chrome>, C<firefox>, C<brave>, C<edge>, C<opera>, C<vivaldi>.
+
+When set, cookies are extracted on startup and cached for 1 hour. This allows access to
+logged-in content, age-restricted videos, and personalized results without manually
+exporting a cookie file.
+
+Example usage:
+
+    pipe-viewer --cookies-from-browser=chromium
+
+Or in the config file:
+
+    cookies_from_browser => "chromium",
+
+Note: C<cookie_file> takes precedence over C<cookies_from_browser> if both are set.
+
+Requires C<yt-dlp> to be installed.
 
 =head2 copy_caption
 

--- a/lib/WWW/PipeViewer.pm
+++ b/lib/WWW/PipeViewer.pm
@@ -81,7 +81,8 @@ my %valid_options = (
     retry_delay => {valid => qr/^\d+\z/, default => 1},
     config_dir  => {valid => qr/^./,     default => q{.}},
     cache_dir   => {valid => qr/^./,     default => q{.}},
-    cookie_file => {valid => qr/^./,     default => undef},
+    cookie_file          => {valid => qr/^./,     default => undef},
+    cookies_from_browser => {valid => qr/^\w+/,   default => undef},
 
     # Support for yt-dlp / youtube-dl
     ytdl     => {valid => [1, 0], default => 1},
@@ -329,6 +330,12 @@ sub _setup_cookies {
     my ($self, $agent) = @_;
 
     my $cookie_file = $self->get_cookie_file;
+    my $browser     = $self->get_cookies_from_browser;
+
+    # If cookies_from_browser is set, extract cookies via yt-dlp
+    if (defined($browser) and !defined($cookie_file)) {
+        $cookie_file = $self->_extract_browser_cookies($browser);
+    }
 
     if (defined($cookie_file) and -f $cookie_file) {
         if ($self->get_debug) {
@@ -350,6 +357,50 @@ sub _setup_cookies {
         $self->_set_default_cookies($cookies);
         $agent->cookie_jar($cookies);
     }
+}
+
+sub _extract_browser_cookies {
+    my ($self, $browser) = @_;
+
+    require File::Spec;
+
+    my $cache_dir   = $self->get_cache_dir // File::Spec->tmpdir;
+    my $cookie_file = File::Spec->catfile($cache_dir, "cookies_from_${browser}.txt");
+
+    # Re-use cached file if it exists and is less than 1 hour old
+    if (-f $cookie_file && (time() - (stat($cookie_file))[9]) < 3600) {
+        if ($self->get_debug) {
+            say STDERR ":: Reusing cached browser cookies: $cookie_file";
+        }
+        return $cookie_file;
+    }
+
+    my $ytdl_cmd = $self->get_ytdl_cmd // 'yt-dlp';
+
+    if ($self->get_debug) {
+        say STDERR ":: Extracting cookies from browser: $browser";
+    }
+
+    my @cmd = (
+        $ytdl_cmd,
+        '--cookies-from-browser', $browser,
+        '--cookies',              $cookie_file,
+        '--skip-download',
+        '--print',                '',
+        'https://www.youtube.com',
+    );
+
+    my $exit_code = system(@cmd);
+
+    if ($exit_code == 0 && -f $cookie_file && -s $cookie_file) {
+        if ($self->get_debug) {
+            say STDERR ":: Browser cookies extracted to: $cookie_file";
+        }
+        return $cookie_file;
+    }
+
+    warn ":: Warning: failed to extract cookies from browser '$browser' (exit code: $exit_code)\n";
+    return undef;
 }
 
 sub _set_default_cookies {


### PR DESCRIPTION
## Summary

Adds `--cookies-from-browser` support to pipe-viewer, allowing automatic extraction of cookies from installed browsers (Chromium, Firefox, Chrome, Brave, Edge, Opera, Vivaldi) via yt-dlp.

This enables pipe-viewer to access:
- **Logged-in YouTube content** — subscriptions, playlists, watch history
- **Age-restricted videos** — without manual cookie export
- **Personalized search results** and recommendations
- **Members-only content** (if applicable)

## Motivation

Currently, users who want to use their YouTube account with pipe-viewer must manually export a Netscape cookie file from their browser and configure `cookie_file`. This is tedious and the cookies expire quickly.

yt-dlp already has robust browser cookie extraction support (`--cookies-from-browser`), and since yt-dlp is already a dependency of pipe-viewer, we can leverage it directly.

## Usage

**CLI:**
```bash
pipe-viewer --cookies-from-browser=chromium
```

**Config file (`~/.config/pipe-viewer/pipe-viewer.conf`):**
```perl
cookies_from_browser => "chromium",
```

**GTK config (`~/.config/pipe-viewer/gtk-pipe-viewer.conf`):**
```perl
cookies_from_browser => "chromium",
```

## Implementation

### Changes

- **`lib/WWW/PipeViewer.pm`**: Added `cookies_from_browser` config option and `_extract_browser_cookies()` method. When set, cookies are extracted via yt-dlp on startup and cached for 1 hour in the cache directory to avoid repeated extraction overhead. `cookie_file` takes precedence if both are set.

- **`bin/pipe-viewer`**: Added `--cookies-from-browser=s` CLI flag, config file support, and POD documentation.

- **`bin/gtk-pipe-viewer`**: Added `cookies_from_browser` to the config defaults and worker pass-through list.

### How it works

1. On startup, if `cookies_from_browser` is set (and `cookie_file` is not), `_extract_browser_cookies()` is called
2. It runs `yt-dlp --cookies-from-browser BROWSER --cookies TEMPFILE --skip-download https://www.youtube.com`
3. The resulting Netscape cookie file is cached in the cache directory (1-hour TTL)
4. The cached file is loaded via the existing `HTTP::Cookies::Netscape` mechanism

### Browser support

All browsers supported by yt-dlp: `chromium`, `chrome`, `firefox`, `brave`, `edge`, `opera`, `vivaldi`

## Testing

Tested on Debian 12 (bookworm) with Chromium:
- `pipe-viewer --cookies-from-browser=chromium --debug "test"` — cookies extracted successfully, search results returned
- Second run shows "Reusing cached browser cookies" — caching works
- `pipe-viewer --cookies=FILE` still works as before (no regression)
- Perl syntax check passes for all three modified files